### PR TITLE
fix: SonarCloud reporting issues

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/TisTraineeReferenceApplication.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/TisTraineeReferenceApplication.java
@@ -21,8 +21,9 @@
 
 package uk.nhs.hee.tis.trainee.reference;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static springfox.documentation.builders.PathSelectors.regex;
+
+import java.util.Collections;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -32,28 +33,21 @@ import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
-import java.util.Collections;
-
-import static springfox.documentation.builders.PathSelectors.regex;
-
 @SpringBootApplication
 @EnableSwagger2
 public class TisTraineeReferenceApplication {
 
-  private static final Logger log = LoggerFactory.getLogger(TisTraineeReferenceApplication.class);
-
   public static void main(String[] args) {
-    SpringApplication.run(TisTraineeReferenceApplication.class, args);
+    SpringApplication.run(TisTraineeReferenceApplication.class);
   }
 
   /**
-    * Configure swagger.
-    *
-    * @return The swagger configuration {@link Docket}.
-    */
+   * Configure swagger.
+   *
+   * @return The swagger configuration {@link Docket}.
+   */
   @Bean
   public Docket swaggerConfiguration() {
-
     return new Docket(DocumentationType.SWAGGER_2)
         .select()
         .paths(regex("/api.*"))


### PR DESCRIPTION
SonarCloud reported several issues that can be resolved with the
following steps in TisTraineeReferenceApplication
 - Organize imports to enforce the proper ordering
 - Remove the unused logger
 - Do not pass the command line args through to the spring application,
   it is not expected that we need to do this.

TISNEW-3946