### PR TITLE
chore: Remove duplicate checks from build workflow

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -89,9 +89,6 @@ jobs:
         with:
           java-version: 11
 
-      - name: Run checks
-        run: ./gradlew check
-
       - name: Run quality analysis
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The analyze step runs `./gradlew check` when it does not need to, the
reports are provided from the check and test jobs.

TISNEW-3848