### PR TITLE
chore: Change default image tag to a valid tag

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -2,7 +2,7 @@
   "containerDefinitions": [
     {
       "name": "tis-trainee-reference",
-      "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-trainee-reference:1b991805cc8e47b6eb69a7f6b515756e772d8243",
+      "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-trainee-reference:04b9c6e5971d3c3839f9d6d691ffa492a4af494d",
       "portMappings": [
         {
           "containerPort": 8205


### PR DESCRIPTION
The task definition's default image tag should point to a valid image.

TISNEW-3848