### PR TITLE
refactor: MongoDB connection configuration

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,6 @@ server:
 spring:
   data:
     mongodb:
-      uri: mongodb://${DB_HOST:localhost}:${DB_PORT:27017}
-      database: ${DB_NAME:reference}
+      uri: mongodb://${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:reference}
       username: ${DB_USER:admin}
       password: ${DB_PASSWORD:pwd}


### PR DESCRIPTION
The current URI string containing the username and password works for
AWS DocumentDB but does not work with dockerized MongoDB.
Move the username and password out of the URI, this works locally but
needs testing with DocumentDB.

TISNEW-3848