### PR TITLE
refactor: Standardize DTO and Entity field names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = 'uk.nhs.hee.tis.trainee'
-version = '0.0.1'
+version = '0.0.2'
 sourceCompatibility = '11'
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/CollegeDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/CollegeDto.java
@@ -30,6 +30,6 @@ import lombok.Data;
 public class CollegeDto {
 
   private String id;
-  private String collegeTisId;
+  private String tisId;
   private String label;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/CurriculumDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/CurriculumDto.java
@@ -29,6 +29,6 @@ import lombok.Data;
 public class CurriculumDto {
 
   private String id;
-  private String curriculumTisId;
+  private String tisId;
   private String label;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/GenderDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/GenderDto.java
@@ -30,6 +30,6 @@ import lombok.Data;
 public class GenderDto {
 
   private String id;
-  private String genderTisId;
+  private String tisId;
   private String label;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/GradeDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/GradeDto.java
@@ -30,7 +30,6 @@ import lombok.Data;
 public class GradeDto {
 
   private String id;
-  private String gradeTisId;
-  private String abbreviation;
+  private String tisId;
   private String label;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/LocalOfficeDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/LocalOfficeDto.java
@@ -30,7 +30,6 @@ import lombok.Data;
 public class LocalOfficeDto {
 
   private String id;
-  private String localOfficeTisId;
+  private String tisId;
   private String label;
-  private String entityId;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/QualificationDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/QualificationDto.java
@@ -30,6 +30,6 @@ import lombok.Data;
 public class QualificationDto {
 
   private String id;
-  private String qualificationTisId;
+  private String tisId;
   private String label;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/model/College.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/model/College.java
@@ -25,7 +25,6 @@ import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "College")
 @Data
@@ -35,7 +34,6 @@ public class College {
   private String id;
 
   @Indexed(unique = true)
-  @Field(value = "collegeTisId")
-  private String collegeTisId;
+  private String tisId;
   private String label;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/model/Curriculum.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/model/Curriculum.java
@@ -24,7 +24,6 @@ import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "Curriculum")
 @Data
@@ -34,7 +33,6 @@ public class Curriculum {
   private String id;
 
   @Indexed(unique = true)
-  @Field(value = "curriculumTisId")
-  private String curriculumTisId;
+  private String tisId;
   private String label;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/model/Gender.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/model/Gender.java
@@ -25,7 +25,6 @@ import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "Gender")
 @Data
@@ -35,7 +34,6 @@ public class Gender {
   private String id;
 
   @Indexed(unique = true)
-  @Field(value = "genderTisId")
-  private String genderTisId;
+  private String tisId;
   private String label;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/model/Grade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/model/Grade.java
@@ -25,7 +25,6 @@ import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "Grade")
 @Data
@@ -35,10 +34,6 @@ public class Grade {
   private String id;
 
   @Indexed(unique = true)
-  @Field(value = "gradeTisId")
-  private String gradeTisId;
-
-  private String abbreviation;
-
+  private String tisId;
   private String label;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/model/LocalOffice.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/model/LocalOffice.java
@@ -25,7 +25,6 @@ import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "LocalOffice")
 @Data
@@ -35,8 +34,6 @@ public class LocalOffice {
   private String id;
 
   @Indexed(unique = true)
-  @Field(value = "localOfficeTisId")
-  private String localOfficeTisId;
+  private String tisId;
   private String label;
-  private String entityId;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/model/Qualification.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/model/Qualification.java
@@ -25,7 +25,6 @@ import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "Qualification")
 @Data
@@ -35,7 +34,6 @@ public class Qualification {
   private String id;
 
   @Indexed(unique = true)
-  @Field(value = "qualificationTisId")
-  private String qualificationTisId;
+  private String tisId;
   private String label;
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/CollegeResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/CollegeResourceTest.java
@@ -95,22 +95,22 @@ public class CollegeResourceTest {
   public void initData() {
     college1 = new College();
     college1.setId(DEFAULT_ID_1);
-    college1.setCollegeTisId(DEFAULT_TIS_ID_1);
+    college1.setTisId(DEFAULT_TIS_ID_1);
     college1.setLabel(DEFAULT_LABEL_1);
 
     college2 = new College();
     college2.setId(DEFAULT_ID_2);
-    college2.setCollegeTisId(DEFAULT_TIS_ID_2);
+    college2.setTisId(DEFAULT_TIS_ID_2);
     college2.setLabel(DEFAULT_LABEL_2);
 
     collegeDto1 = new CollegeDto();
     collegeDto1.setId(DEFAULT_ID_1);
-    collegeDto1.setCollegeTisId(DEFAULT_TIS_ID_1);
+    collegeDto1.setTisId(DEFAULT_TIS_ID_1);
     collegeDto1.setLabel(DEFAULT_LABEL_1);
 
     collegeDto2 = new CollegeDto();
     collegeDto2.setId(DEFAULT_ID_2);
-    collegeDto2.setCollegeTisId(DEFAULT_TIS_ID_2);
+    collegeDto2.setTisId(DEFAULT_TIS_ID_2);
     collegeDto2.setLabel(DEFAULT_LABEL_2);
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/CurriculumResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/CurriculumResourceTest.java
@@ -94,22 +94,22 @@ public class CurriculumResourceTest {
   public void initData() {
     curriculum1 = new Curriculum();
     curriculum1.setId(DEFAULT_ID_1);
-    curriculum1.setCurriculumTisId(DEFAULT_TIS_ID_1);
+    curriculum1.setTisId(DEFAULT_TIS_ID_1);
     curriculum1.setLabel(DEFAULT_LABEL_1);
 
     curriculum2 = new Curriculum();
     curriculum2.setId(DEFAULT_ID_2);
-    curriculum2.setCurriculumTisId(DEFAULT_TIS_ID_2);
+    curriculum2.setTisId(DEFAULT_TIS_ID_2);
     curriculum2.setLabel(DEFAULT_LABEL_2);
 
     curriculumDto1 = new CurriculumDto();
     curriculumDto1.setId(DEFAULT_ID_1);
-    curriculumDto1.setCurriculumTisId(DEFAULT_TIS_ID_1);
+    curriculumDto1.setTisId(DEFAULT_TIS_ID_1);
     curriculumDto1.setLabel(DEFAULT_LABEL_1);
 
     curriculumDto2 = new CurriculumDto();
     curriculumDto2.setId(DEFAULT_ID_2);
-    curriculumDto2.setCurriculumTisId(DEFAULT_TIS_ID_2);
+    curriculumDto2.setTisId(DEFAULT_TIS_ID_2);
     curriculumDto2.setLabel(DEFAULT_LABEL_2);
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/GenderResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/GenderResourceTest.java
@@ -94,22 +94,22 @@ public class GenderResourceTest {
   public void initData() {
     gender1 = new Gender();
     gender1.setId(DEFAULT_ID_1);
-    gender1.setGenderTisId(DEFAULT_TIS_ID_1);
+    gender1.setTisId(DEFAULT_TIS_ID_1);
     gender1.setLabel(DEFAULT_LABEL_1);
 
     gender2 = new Gender();
     gender2.setId(DEFAULT_ID_2);
-    gender2.setGenderTisId(DEFAULT_TIS_ID_2);
+    gender2.setTisId(DEFAULT_TIS_ID_2);
     gender2.setLabel(DEFAULT_LABEL_2);
 
     genderDto1 = new GenderDto();
     genderDto1.setId(DEFAULT_ID_1);
-    genderDto1.setGenderTisId(DEFAULT_TIS_ID_1);
+    genderDto1.setTisId(DEFAULT_TIS_ID_1);
     genderDto1.setLabel(DEFAULT_LABEL_1);
 
     genderDto2 = new GenderDto();
     genderDto2.setId(DEFAULT_ID_2);
-    genderDto2.setGenderTisId(DEFAULT_TIS_ID_2);
+    genderDto2.setTisId(DEFAULT_TIS_ID_2);
     genderDto2.setLabel(DEFAULT_LABEL_2);
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/GradeResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/GradeResourceTest.java
@@ -98,26 +98,22 @@ public class GradeResourceTest {
   public void initData() {
     grade1 = new Grade();
     grade1.setId(DEFAULT_ID_1);
-    grade1.setGradeTisId(DEFAULT_TIS_ID_1);
-    grade1.setAbbreviation(DEFAULT_ABBREVIATION_1);
+    grade1.setTisId(DEFAULT_TIS_ID_1);
     grade1.setLabel(DEFAULT_LABEL_1);
 
     grade2 = new Grade();
     grade2.setId(DEFAULT_ID_2);
-    grade2.setGradeTisId(DEFAULT_TIS_ID_2);
-    grade2.setAbbreviation(DEFAULT_ABBREVIATION_2);
+    grade2.setTisId(DEFAULT_TIS_ID_2);
     grade2.setLabel(DEFAULT_LABEL_2);
 
     gradeDto1 = new GradeDto();
     gradeDto1.setId(DEFAULT_ID_1);
-    gradeDto1.setGradeTisId(DEFAULT_TIS_ID_1);
-    gradeDto1.setAbbreviation(DEFAULT_ABBREVIATION_1);
+    gradeDto1.setTisId(DEFAULT_TIS_ID_1);
     gradeDto1.setLabel(DEFAULT_LABEL_1);
 
     gradeDto2 = new GradeDto();
     gradeDto2.setId(DEFAULT_ID_2);
-    gradeDto2.setGradeTisId(DEFAULT_TIS_ID_2);
-    gradeDto2.setAbbreviation(DEFAULT_ABBREVIATION_2);
+    gradeDto2.setTisId(DEFAULT_TIS_ID_2);
     gradeDto2.setLabel(DEFAULT_LABEL_2);
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/ImmigrationStatusResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/ImmigrationStatusResourceTest.java
@@ -33,7 +33,6 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeResourceTest.java
@@ -99,27 +99,23 @@ public class LocalOfficeResourceTest {
   public void initData() {
     localOffice1 = new LocalOffice();
     localOffice1.setId(DEFAULT_ID_1);
-    localOffice1.setLocalOfficeTisId(DEFAULT_TIS_ID_1);
+    localOffice1.setTisId(DEFAULT_TIS_ID_1);
     localOffice1.setLabel(DEFAULT_LABEL_1);
-    localOffice1.setEntityId(DEFAULT_ENTITY_ID_1);
 
     localOffice2 = new LocalOffice();
     localOffice2.setId(DEFAULT_ID_2);
-    localOffice2.setLocalOfficeTisId(DEFAULT_TIS_ID_2);
+    localOffice2.setTisId(DEFAULT_TIS_ID_2);
     localOffice2.setLabel(DEFAULT_LABEL_2);
-    localOffice2.setEntityId(DEFAULT_ENTITY_ID_2);
 
     localOfficeDto1 = new LocalOfficeDto();
     localOfficeDto1.setId(DEFAULT_ID_1);
-    localOfficeDto1.setLocalOfficeTisId(DEFAULT_TIS_ID_1);
+    localOfficeDto1.setTisId(DEFAULT_TIS_ID_1);
     localOfficeDto1.setLabel(DEFAULT_LABEL_1);
-    localOfficeDto1.setEntityId(DEFAULT_ENTITY_ID_1);
 
     localOfficeDto2 = new LocalOfficeDto();
     localOfficeDto2.setId(DEFAULT_ID_2);
-    localOfficeDto2.setLocalOfficeTisId(DEFAULT_TIS_ID_2);
+    localOfficeDto2.setTisId(DEFAULT_TIS_ID_2);
     localOfficeDto2.setLabel(DEFAULT_LABEL_2);
-    localOfficeDto2.setEntityId(DEFAULT_ENTITY_ID_2);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/QualificationResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/QualificationResourceTest.java
@@ -95,22 +95,22 @@ public class QualificationResourceTest {
   public void initData() {
     qualification1 = new Qualification();
     qualification1.setId(DEFAULT_ID_1);
-    qualification1.setQualificationTisId(DEFAULT_TIS_ID_1);
+    qualification1.setTisId(DEFAULT_TIS_ID_1);
     qualification1.setLabel(DEFAULT_LABEL_1);
 
     qualification2 = new Qualification();
     qualification2.setId(DEFAULT_ID_2);
-    qualification2.setQualificationTisId(DEFAULT_TIS_ID_2);
+    qualification2.setTisId(DEFAULT_TIS_ID_2);
     qualification2.setLabel(DEFAULT_LABEL_2);
 
     qualificationDto1 = new QualificationDto();
     qualificationDto1.setId(DEFAULT_ID_1);
-    qualificationDto1.setQualificationTisId(DEFAULT_TIS_ID_1);
+    qualificationDto1.setTisId(DEFAULT_TIS_ID_1);
     qualificationDto1.setLabel(DEFAULT_LABEL_1);
 
     qualificationDto2 = new QualificationDto();
     qualificationDto2.setId(DEFAULT_ID_2);
-    qualificationDto2.setQualificationTisId(DEFAULT_TIS_ID_2);
+    qualificationDto2.setTisId(DEFAULT_TIS_ID_2);
     qualificationDto2.setLabel(DEFAULT_LABEL_2);
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/CollegeServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/CollegeServiceImplTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.nhs.hee.tis.trainee.reference.dto.CollegeDto;
 import uk.nhs.hee.tis.trainee.reference.model.College;
 import uk.nhs.hee.tis.trainee.reference.repository.CollegeRepository;
 import uk.nhs.hee.tis.trainee.reference.service.impl.CollegeServiceImpl;
@@ -58,8 +57,6 @@ public class CollegeServiceImplTest {
 
   private College college1;
   private College college2;
-  private CollegeDto collegeDto1;
-  private CollegeDto collegeDto2;
 
   /**
    * Set up data.
@@ -68,23 +65,13 @@ public class CollegeServiceImplTest {
   public void initData() {
     college1 = new College();
     college1.setId(DEFAULT_ID_1);
-    college1.setCollegeTisId(DEFAULT_TIS_ID_1);
+    college1.setTisId(DEFAULT_TIS_ID_1);
     college1.setLabel(DEFAULT_LABEL_1);
 
     college2 = new College();
     college2.setId(DEFAULT_ID_2);
-    college2.setCollegeTisId(DEFAULT_TIS_ID_2);
+    college2.setTisId(DEFAULT_TIS_ID_2);
     college2.setLabel(DEFAULT_LABEL_2);
-
-    collegeDto1 = new CollegeDto();
-    collegeDto1.setId(DEFAULT_ID_1);
-    collegeDto1.setCollegeTisId(DEFAULT_TIS_ID_1);
-    collegeDto1.setLabel(DEFAULT_LABEL_1);
-
-    collegeDto2 = new CollegeDto();
-    collegeDto2.setId(DEFAULT_ID_2);
-    collegeDto2.setCollegeTisId(DEFAULT_TIS_ID_2);
-    collegeDto2.setLabel(DEFAULT_LABEL_2);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/CurriculumServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/CurriculumServiceImplTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.nhs.hee.tis.trainee.reference.dto.CurriculumDto;
 import uk.nhs.hee.tis.trainee.reference.model.Curriculum;
 import uk.nhs.hee.tis.trainee.reference.repository.CurriculumRepository;
 import uk.nhs.hee.tis.trainee.reference.service.impl.CurriculumServiceImpl;
@@ -57,8 +56,6 @@ public class CurriculumServiceImplTest {
 
   private Curriculum curriculum1;
   private Curriculum curriculum2;
-  private CurriculumDto curriculumDto1;
-  private CurriculumDto curriculumDto2;
 
   /**
    * Set up data.
@@ -67,23 +64,13 @@ public class CurriculumServiceImplTest {
   public void initData() {
     curriculum1 = new Curriculum();
     curriculum1.setId(DEFAULT_ID_1);
-    curriculum1.setCurriculumTisId(DEFAULT_TIS_ID_1);
+    curriculum1.setTisId(DEFAULT_TIS_ID_1);
     curriculum1.setLabel(DEFAULT_LABEL_1);
 
     curriculum2 = new Curriculum();
     curriculum2.setId(DEFAULT_ID_2);
-    curriculum2.setCurriculumTisId(DEFAULT_TIS_ID_2);
+    curriculum2.setTisId(DEFAULT_TIS_ID_2);
     curriculum2.setLabel(DEFAULT_LABEL_2);
-
-    curriculumDto1 = new CurriculumDto();
-    curriculumDto1.setId(DEFAULT_ID_1);
-    curriculumDto1.setCurriculumTisId(DEFAULT_TIS_ID_1);
-    curriculumDto1.setLabel(DEFAULT_LABEL_1);
-
-    curriculumDto2 = new CurriculumDto();
-    curriculumDto2.setId(DEFAULT_ID_2);
-    curriculumDto2.setCurriculumTisId(DEFAULT_TIS_ID_2);
-    curriculumDto2.setLabel(DEFAULT_LABEL_2);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/GenderServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/GenderServiceImplTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.nhs.hee.tis.trainee.reference.dto.GenderDto;
 import uk.nhs.hee.tis.trainee.reference.model.Gender;
 import uk.nhs.hee.tis.trainee.reference.repository.GenderRepository;
 import uk.nhs.hee.tis.trainee.reference.service.impl.GenderServiceImpl;
@@ -58,8 +57,6 @@ public class GenderServiceImplTest {
 
   private Gender gender1;
   private Gender gender2;
-  private GenderDto genderDto1;
-  private GenderDto genderDto2;
 
   /**
    * Set up data.
@@ -68,23 +65,13 @@ public class GenderServiceImplTest {
   public void initData() {
     gender1 = new Gender();
     gender1.setId(DEFAULT_ID_1);
-    gender1.setGenderTisId(DEFAULT_TIS_ID_1);
+    gender1.setTisId(DEFAULT_TIS_ID_1);
     gender1.setLabel(DEFAULT_LABEL_1);
 
     gender2 = new Gender();
     gender2.setId(DEFAULT_ID_2);
-    gender2.setGenderTisId(DEFAULT_TIS_ID_2);
+    gender2.setTisId(DEFAULT_TIS_ID_2);
     gender2.setLabel(DEFAULT_LABEL_2);
-
-    genderDto1 = new GenderDto();
-    genderDto1.setId(DEFAULT_ID_1);
-    genderDto1.setGenderTisId(DEFAULT_TIS_ID_1);
-    genderDto1.setLabel(DEFAULT_LABEL_1);
-
-    genderDto2 = new GenderDto();
-    genderDto2.setId(DEFAULT_ID_2);
-    genderDto2.setGenderTisId(DEFAULT_TIS_ID_2);
-    genderDto2.setLabel(DEFAULT_LABEL_2);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/GradeServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/GradeServiceImplTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.nhs.hee.tis.trainee.reference.dto.GradeDto;
 import uk.nhs.hee.tis.trainee.reference.model.Grade;
 import uk.nhs.hee.tis.trainee.reference.repository.GradeRepository;
 import uk.nhs.hee.tis.trainee.reference.service.impl.GradeServiceImpl;
@@ -61,8 +60,6 @@ public class GradeServiceImplTest {
 
   private Grade grade1;
   private Grade grade2;
-  private GradeDto gradeDto1;
-  private GradeDto gradeDto2;
 
   /**
    * Set up data.
@@ -71,27 +68,13 @@ public class GradeServiceImplTest {
   public void initData() {
     grade1 = new Grade();
     grade1.setId(DEFAULT_ID_1);
-    grade1.setGradeTisId(DEFAULT_TIS_ID_1);
-    grade1.setAbbreviation(DEFAULT_ABBREVIATION_1);
+    grade1.setTisId(DEFAULT_TIS_ID_1);
     grade1.setLabel(DEFAULT_LABEL_1);
 
     grade2 = new Grade();
     grade2.setId(DEFAULT_ID_2);
-    grade2.setGradeTisId(DEFAULT_TIS_ID_2);
-    grade2.setAbbreviation(DEFAULT_ABBREVIATION_2);
+    grade2.setTisId(DEFAULT_TIS_ID_2);
     grade2.setLabel(DEFAULT_LABEL_2);
-
-    gradeDto1 = new GradeDto();
-    gradeDto1.setId(DEFAULT_ID_1);
-    gradeDto1.setGradeTisId(DEFAULT_TIS_ID_1);
-    gradeDto1.setAbbreviation(DEFAULT_ABBREVIATION_1);
-    gradeDto1.setLabel(DEFAULT_LABEL_1);
-
-    gradeDto2 = new GradeDto();
-    gradeDto2.setId(DEFAULT_ID_2);
-    gradeDto2.setGradeTisId(DEFAULT_TIS_ID_2);
-    gradeDto2.setAbbreviation(DEFAULT_ABBREVIATION_2);
-    gradeDto2.setLabel(DEFAULT_LABEL_2);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/ImmigrationStatusServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/ImmigrationStatusServiceImplTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.nhs.hee.tis.trainee.reference.dto.ImmigrationStatusDto;
 import uk.nhs.hee.tis.trainee.reference.model.ImmigrationStatus;
 import uk.nhs.hee.tis.trainee.reference.repository.ImmigrationStatusRepository;
 import uk.nhs.hee.tis.trainee.reference.service.impl.ImmigrationStatusServiceImpl;
@@ -54,8 +53,6 @@ public class ImmigrationStatusServiceImplTest {
 
   private ImmigrationStatus immigrationStatus1;
   private ImmigrationStatus immigrationStatus2;
-  private ImmigrationStatusDto immigrationStatusDto1;
-  private ImmigrationStatusDto immigrationStatusDto2;
 
   /**
    * Set up data.
@@ -69,14 +66,6 @@ public class ImmigrationStatusServiceImplTest {
     immigrationStatus2 = new ImmigrationStatus();
     immigrationStatus2.setId(DEFAULT_ID_2);
     immigrationStatus2.setLabel(DEFAULT_LABEL_2);
-
-    immigrationStatusDto1 = new ImmigrationStatusDto();
-    immigrationStatusDto1.setId(DEFAULT_ID_1);
-    immigrationStatusDto1.setLabel(DEFAULT_LABEL_1);
-
-    immigrationStatusDto2 = new ImmigrationStatusDto();
-    immigrationStatusDto2.setId(DEFAULT_ID_2);
-    immigrationStatusDto2.setLabel(DEFAULT_LABEL_2);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeServiceImplTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.nhs.hee.tis.trainee.reference.dto.LocalOfficeDto;
 import uk.nhs.hee.tis.trainee.reference.model.LocalOffice;
 import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeRepository;
 import uk.nhs.hee.tis.trainee.reference.service.impl.LocalOfficeServiceImpl;
@@ -51,9 +50,6 @@ public class LocalOfficeServiceImplTest {
   private static final String DEFAULT_LABEL_2 =
       "Northern Ireland Medical and Dental Training Agency";
 
-  private static final String DEFAULT_ENTITY_ID_1 = "1";
-  private static final String DEFAULT_ENTITY_ID_2 = "2";
-
   @InjectMocks
   private LocalOfficeServiceImpl localOfficeServiceImpl;
 
@@ -62,8 +58,6 @@ public class LocalOfficeServiceImplTest {
 
   private LocalOffice localOffice1;
   private LocalOffice localOffice2;
-  private LocalOfficeDto localOfficeDto1;
-  private LocalOfficeDto localOfficeDto2;
 
   /**
    * Set up data.
@@ -72,27 +66,13 @@ public class LocalOfficeServiceImplTest {
   public void initData() {
     localOffice1 = new LocalOffice();
     localOffice1.setId(DEFAULT_ID_1);
-    localOffice1.setLocalOfficeTisId(DEFAULT_TIS_ID_1);
+    localOffice1.setTisId(DEFAULT_TIS_ID_1);
     localOffice1.setLabel(DEFAULT_LABEL_1);
-    localOffice1.setEntityId(DEFAULT_ENTITY_ID_1);
 
     localOffice2 = new LocalOffice();
     localOffice2.setId(DEFAULT_ID_2);
-    localOffice2.setLocalOfficeTisId(DEFAULT_TIS_ID_2);
+    localOffice2.setTisId(DEFAULT_TIS_ID_2);
     localOffice2.setLabel(DEFAULT_LABEL_2);
-    localOffice2.setEntityId(DEFAULT_ENTITY_ID_2);
-
-    localOfficeDto1 = new LocalOfficeDto();
-    localOfficeDto1.setId(DEFAULT_ID_1);
-    localOfficeDto1.setLocalOfficeTisId(DEFAULT_TIS_ID_1);
-    localOfficeDto1.setLabel(DEFAULT_LABEL_1);
-    localOfficeDto1.setEntityId(DEFAULT_ENTITY_ID_1);
-
-    localOfficeDto2 = new LocalOfficeDto();
-    localOfficeDto2.setId(DEFAULT_ID_2);
-    localOfficeDto2.setLocalOfficeTisId(DEFAULT_TIS_ID_2);
-    localOfficeDto2.setLabel(DEFAULT_LABEL_2);
-    localOfficeDto2.setEntityId(DEFAULT_ENTITY_ID_2);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/QualificationServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/QualificationServiceImplTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.nhs.hee.tis.trainee.reference.dto.QualificationDto;
 import uk.nhs.hee.tis.trainee.reference.model.Qualification;
 import uk.nhs.hee.tis.trainee.reference.repository.QualificationRepository;
 import uk.nhs.hee.tis.trainee.reference.service.impl.QualificationServiceImpl;
@@ -58,8 +57,6 @@ public class QualificationServiceImplTest {
 
   private Qualification qualification1;
   private Qualification qualification2;
-  private QualificationDto qualificationDto1;
-  private QualificationDto qualificationDto2;
 
   /**
    * Set up data.
@@ -68,23 +65,13 @@ public class QualificationServiceImplTest {
   public void initData() {
     qualification1 = new Qualification();
     qualification1.setId(DEFAULT_ID_1);
-    qualification1.setQualificationTisId(DEFAULT_TIS_ID_1);
+    qualification1.setTisId(DEFAULT_TIS_ID_1);
     qualification1.setLabel(DEFAULT_LABEL_1);
 
     qualification2 = new Qualification();
     qualification2.setId(DEFAULT_ID_2);
-    qualification2.setQualificationTisId(DEFAULT_TIS_ID_2);
+    qualification2.setTisId(DEFAULT_TIS_ID_2);
     qualification2.setLabel(DEFAULT_LABEL_2);
-
-    qualificationDto1 = new QualificationDto();
-    qualificationDto1.setId(DEFAULT_ID_1);
-    qualificationDto1.setQualificationTisId(DEFAULT_TIS_ID_1);
-    qualificationDto1.setLabel(DEFAULT_LABEL_1);
-
-    qualificationDto2 = new QualificationDto();
-    qualificationDto2.setId(DEFAULT_ID_2);
-    qualificationDto2.setQualificationTisId(DEFAULT_TIS_ID_2);
-    qualificationDto2.setLabel(DEFAULT_LABEL_2);
   }
 
   @Test


### PR DESCRIPTION
Refactor the reference types which are sourced from TIS to have a more
consistent field naming of `id`, `tisId`, `label` instead of a unique
field name for the TIS id for each type.

TISNEW-4307