### PR TITLE
feat: Add endpoints to create/update/delete grades

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = 'uk.nhs.hee.tis.trainee'
-version = '0.0.2'
+version = '0.1.0'
 sourceCompatibility = '11'
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/api/GenderResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/api/GenderResource.java
@@ -21,10 +21,17 @@
 
 package uk.nhs.hee.tis.trainee.reference.api;
 
+import java.net.URI;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.tis.trainee.reference.dto.GenderDto;
@@ -38,12 +45,12 @@ public class GenderResource {
 
   private static final Logger log = LoggerFactory.getLogger(GenderResource.class);
 
-  private GenderService genderService;
-  private GenderMapper genderMapper;
+  private GenderService service;
+  private GenderMapper mapper;
 
-  public GenderResource(GenderService genderService, GenderMapper genderMapper) {
-    this.genderService = genderService;
-    this.genderMapper = genderMapper;
+  public GenderResource(GenderService service, GenderMapper mapper) {
+    this.service = service;
+    this.mapper = mapper;
   }
 
   /**
@@ -54,7 +61,44 @@ public class GenderResource {
   @GetMapping("/gender")
   public List<GenderDto> getGender() {
     log.trace("Get all Genders");
-    List<Gender> genders = genderService.getGender();
-    return genderMapper.toDtos(genders);
+    List<Gender> genders = service.getGender();
+    return mapper.toDtos(genders);
+  }
+
+  /**
+   * Create a Gender, or update an existing Gender if the tisID matches.
+   *
+   * @param genderDto The Gender to create.
+   * @return The created (or updated) Gender.
+   */
+  @PostMapping("/gender")
+  public ResponseEntity<GenderDto> createGender(@RequestBody GenderDto genderDto) {
+    Gender gender = mapper.toEntity(genderDto);
+    gender = service.createGender(gender);
+    return ResponseEntity.created(URI.create("/api/gender")).body(mapper.toDto(gender));
+  }
+
+  /**
+   * Update a Gender with a matching tisId value, or creates a new Gender if the ID was not found.
+   *
+   * @param genderDto The Gender details to update.
+   * @return The updated (or created) Gender.
+   */
+  @PutMapping("/gender")
+  public ResponseEntity<GenderDto> updateGender(@RequestBody GenderDto genderDto) {
+    Gender gender = mapper.toEntity(genderDto);
+    gender = service.updateGender(gender);
+    return ResponseEntity.ok(mapper.toDto(gender));
+  }
+
+  /**
+   * Delete the Gender with the given tisId.
+   *
+   * @param tisId The tisId of the Gender to delete.
+   */
+  @DeleteMapping("/gender/{tisId}")
+  public ResponseEntity<Void> deleteGender(@PathVariable String tisId) {
+    service.deleteGender(tisId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/api/ImmigrationStatusResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/api/ImmigrationStatusResource.java
@@ -69,7 +69,7 @@ public class ImmigrationStatusResource {
    * @param immigrationStatusDto The ImmigrationStatus to create.
    * @return The created (or updated) ImmigrationStatus.
    */
-  @PostMapping("/immigrationStatus")
+  @PostMapping("/immigration-status")
   public ResponseEntity<ImmigrationStatusDto> createImmigrationStatus(
       @RequestBody ImmigrationStatusDto immigrationStatusDto) {
     ImmigrationStatus immigrationStatus = mapper.toEntity(immigrationStatusDto);
@@ -85,7 +85,7 @@ public class ImmigrationStatusResource {
    * @param immigrationStatusDto The ImmigrationStatus details to update.
    * @return The updated (or created) ImmigrationStatus.
    */
-  @PutMapping("/immigrationStatus")
+  @PutMapping("/immigration-status")
   public ResponseEntity<ImmigrationStatusDto> updateImmigrationStatus(
       @RequestBody ImmigrationStatusDto immigrationStatusDto) {
     ImmigrationStatus immigrationStatus = mapper.toEntity(immigrationStatusDto);
@@ -98,7 +98,7 @@ public class ImmigrationStatusResource {
    *
    * @param tisId The tisId of the ImmigrationStatus to delete.
    */
-  @DeleteMapping("/immigrationStatus/{tisId}")
+  @DeleteMapping("/immigration-status/{tisId}")
   public ResponseEntity<Void> deleteImmigrationStatus(@PathVariable String tisId) {
     service.deleteImmigrationStatus(tisId);
     return ResponseEntity.noContent().build();

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/api/ImmigrationStatusResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/api/ImmigrationStatusResource.java
@@ -20,10 +20,16 @@
 
 package uk.nhs.hee.tis.trainee.reference.api;
 
+import java.net.URI;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.tis.trainee.reference.dto.ImmigrationStatusDto;
@@ -31,19 +37,18 @@ import uk.nhs.hee.tis.trainee.reference.mapper.ImmigrationStatusMapper;
 import uk.nhs.hee.tis.trainee.reference.model.ImmigrationStatus;
 import uk.nhs.hee.tis.trainee.reference.service.ImmigrationStatusService;
 
+@Slf4j
 @RestController
 @RequestMapping("/api")
 public class ImmigrationStatusResource {
 
-  private static final Logger log = LoggerFactory.getLogger(ImmigrationStatusResource.class);
+  private ImmigrationStatusService service;
+  private ImmigrationStatusMapper mapper;
 
-  private ImmigrationStatusService immigrationStatusService;
-  private ImmigrationStatusMapper immigrationStatusMapper;
-
-  public ImmigrationStatusResource(ImmigrationStatusService immigrationStatusService,
-      ImmigrationStatusMapper immigrationStatusMapper) {
-    this.immigrationStatusService = immigrationStatusService;
-    this.immigrationStatusMapper = immigrationStatusMapper;
+  public ImmigrationStatusResource(ImmigrationStatusService service,
+      ImmigrationStatusMapper mapper) {
+    this.service = service;
+    this.mapper = mapper;
   }
 
   /**
@@ -54,7 +59,48 @@ public class ImmigrationStatusResource {
   @GetMapping("/immigration-status")
   public List<ImmigrationStatusDto> getImmigrationStatus() {
     log.trace("Get all ImmigrationStatus");
-    List<ImmigrationStatus> immigrationStatus = immigrationStatusService.getImmigrationStatus();
-    return immigrationStatusMapper.toDtos(immigrationStatus);
+    List<ImmigrationStatus> immigrationStatus = service.getImmigrationStatus();
+    return mapper.toDtos(immigrationStatus);
+  }
+
+  /**
+   * Create an ImmigrationStatus, or update an existing ImmigrationStatus if the tisID matches.
+   *
+   * @param immigrationStatusDto The ImmigrationStatus to create.
+   * @return The created (or updated) ImmigrationStatus.
+   */
+  @PostMapping("/immigrationStatus")
+  public ResponseEntity<ImmigrationStatusDto> createImmigrationStatus(
+      @RequestBody ImmigrationStatusDto immigrationStatusDto) {
+    ImmigrationStatus immigrationStatus = mapper.toEntity(immigrationStatusDto);
+    immigrationStatus = service.createImmigrationStatus(immigrationStatus);
+    return ResponseEntity.created(URI.create("/api/immigrationStatus"))
+        .body(mapper.toDto(immigrationStatus));
+  }
+
+  /**
+   * Update an ImmigrationStatus with a matching tisId value, or creates a new ImmigrationStatus if
+   * the ID was not found.
+   *
+   * @param immigrationStatusDto The ImmigrationStatus details to update.
+   * @return The updated (or created) ImmigrationStatus.
+   */
+  @PutMapping("/immigrationStatus")
+  public ResponseEntity<ImmigrationStatusDto> updateImmigrationStatus(
+      @RequestBody ImmigrationStatusDto immigrationStatusDto) {
+    ImmigrationStatus immigrationStatus = mapper.toEntity(immigrationStatusDto);
+    immigrationStatus = service.updateImmigrationStatus(immigrationStatus);
+    return ResponseEntity.ok(mapper.toDto(immigrationStatus));
+  }
+
+  /**
+   * Delete the ImmigrationStatus with the given tisId.
+   *
+   * @param tisId The tisId of the ImmigrationStatus to delete.
+   */
+  @DeleteMapping("/immigrationStatus/{tisId}")
+  public ResponseEntity<Void> deleteImmigrationStatus(@PathVariable String tisId) {
+    service.deleteImmigrationStatus(tisId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeResource.java
@@ -69,7 +69,7 @@ public class LocalOfficeResource {
    * @param localOfficeDto The LocalOffice to create.
    * @return The created (or updated) LocalOffice.
    */
-  @PostMapping("/localOffice")
+  @PostMapping("/local-office")
   public ResponseEntity<LocalOfficeDto> createLocalOffice(
       @RequestBody LocalOfficeDto localOfficeDto) {
     LocalOffice localOffice = mapper.toEntity(localOfficeDto);
@@ -84,7 +84,7 @@ public class LocalOfficeResource {
    * @param localOfficeDto The LocalOffice details to update.
    * @return The updated (or created) LocalOffice.
    */
-  @PutMapping("/localOffice")
+  @PutMapping("/local-office")
   public ResponseEntity<LocalOfficeDto> updateLocalOffice(
       @RequestBody LocalOfficeDto localOfficeDto) {
     LocalOffice localOffice = mapper.toEntity(localOfficeDto);
@@ -97,7 +97,7 @@ public class LocalOfficeResource {
    *
    * @param tisId The tisId of the LocalOffice to delete.
    */
-  @DeleteMapping("/localOffice/{tisId}")
+  @DeleteMapping("/local-office/{tisId}")
   public ResponseEntity<Void> deleteLocalOffice(@PathVariable String tisId) {
     service.deleteLocalOffice(tisId);
     return ResponseEntity.noContent().build();

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/ImmigrationStatusDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/ImmigrationStatusDto.java
@@ -29,5 +29,6 @@ import lombok.Data;
 public class ImmigrationStatusDto {
 
   private String id;
+  private String tisId;
   private String label;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/CollegeMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/CollegeMapper.java
@@ -23,6 +23,8 @@ package uk.nhs.hee.tis.trainee.reference.mapper;
 
 import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import uk.nhs.hee.tis.trainee.reference.dto.CollegeDto;
 import uk.nhs.hee.tis.trainee.reference.model.College;
 
@@ -36,4 +38,8 @@ public interface CollegeMapper {
   College toEntity(CollegeDto collegeDto);
 
   List<College> toEntities(List<CollegeDto> collegeDtos);
+
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "tisId", ignore = true)
+  College update(@MappingTarget College target, College source);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/GenderMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/GenderMapper.java
@@ -23,6 +23,8 @@ package uk.nhs.hee.tis.trainee.reference.mapper;
 
 import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import uk.nhs.hee.tis.trainee.reference.dto.GenderDto;
 import uk.nhs.hee.tis.trainee.reference.model.Gender;
 
@@ -36,4 +38,8 @@ public interface GenderMapper {
   Gender toEntity(GenderDto genderDto);
 
   List<Gender> toEntities(List<GenderDto> genderDtos);
+
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "tisId", ignore = true)
+  Gender update(@MappingTarget Gender target, Gender source);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/GradeMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/GradeMapper.java
@@ -23,6 +23,8 @@ package uk.nhs.hee.tis.trainee.reference.mapper;
 
 import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import uk.nhs.hee.tis.trainee.reference.dto.GradeDto;
 import uk.nhs.hee.tis.trainee.reference.model.Grade;
 
@@ -36,4 +38,8 @@ public interface GradeMapper {
   Grade toEntity(GradeDto gradeDto);
 
   List<Grade> toEntities(List<GradeDto> gradeDtos);
+
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "tisId", ignore = true)
+  Grade update(@MappingTarget Grade target, Grade source);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/ImmigrationStatusMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/ImmigrationStatusMapper.java
@@ -22,6 +22,8 @@ package uk.nhs.hee.tis.trainee.reference.mapper;
 
 import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import uk.nhs.hee.tis.trainee.reference.dto.ImmigrationStatusDto;
 import uk.nhs.hee.tis.trainee.reference.model.ImmigrationStatus;
 
@@ -35,4 +37,8 @@ public interface ImmigrationStatusMapper {
   ImmigrationStatus toEntity(ImmigrationStatusDto immigrationStatusDto);
 
   List<ImmigrationStatus> toEntities(List<ImmigrationStatusDto> immigrationStatusDtos);
+
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "tisId", ignore = true)
+  ImmigrationStatus update(@MappingTarget ImmigrationStatus target, ImmigrationStatus source);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/LocalOfficeMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/LocalOfficeMapper.java
@@ -23,6 +23,8 @@ package uk.nhs.hee.tis.trainee.reference.mapper;
 
 import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import uk.nhs.hee.tis.trainee.reference.dto.LocalOfficeDto;
 import uk.nhs.hee.tis.trainee.reference.model.LocalOffice;
 
@@ -36,4 +38,8 @@ public interface LocalOfficeMapper {
   LocalOffice toEntity(LocalOfficeDto localOfficeDto);
 
   List<LocalOffice> toEntities(List<LocalOfficeDto> localOfficeDtos);
+
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "tisId", ignore = true)
+  LocalOffice update(@MappingTarget LocalOffice target, LocalOffice source);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/model/ImmigrationStatus.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/model/ImmigrationStatus.java
@@ -30,6 +30,6 @@ public class ImmigrationStatus {
 
   @Id
   private String id;
-
+  private String tisId;
   private String label;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/repository/CollegeRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/repository/CollegeRepository.java
@@ -28,4 +28,7 @@ import uk.nhs.hee.tis.trainee.reference.model.College;
 @Repository
 public interface CollegeRepository extends MongoRepository<College, String> {
 
+  void deleteByTisId(String tisId);
+
+  College findByTisId(String tisId);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/repository/GenderRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/repository/GenderRepository.java
@@ -28,4 +28,7 @@ import uk.nhs.hee.tis.trainee.reference.model.Gender;
 @Repository
 public interface GenderRepository extends MongoRepository<Gender, String> {
 
+  void deleteByTisId(String tisId);
+
+  Gender findByTisId(String tisId);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/repository/GradeRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/repository/GradeRepository.java
@@ -28,4 +28,7 @@ import uk.nhs.hee.tis.trainee.reference.model.Grade;
 @Repository
 public interface GradeRepository extends MongoRepository<Grade, String> {
 
+  void deleteByTisId(String tisId);
+
+  Grade findByTisId(String tisId);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/repository/ImmigrationStatusRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/repository/ImmigrationStatusRepository.java
@@ -27,4 +27,7 @@ import uk.nhs.hee.tis.trainee.reference.model.ImmigrationStatus;
 @Repository
 public interface ImmigrationStatusRepository extends MongoRepository<ImmigrationStatus, String> {
 
+  void deleteByTisId(String tisId);
+
+  ImmigrationStatus findByTisId(String tisId);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/repository/LocalOfficeRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/repository/LocalOfficeRepository.java
@@ -28,4 +28,7 @@ import uk.nhs.hee.tis.trainee.reference.model.LocalOffice;
 @Repository
 public interface LocalOfficeRepository extends MongoRepository<LocalOffice, String> {
 
+  void deleteByTisId(String tisId);
+
+  LocalOffice findByTisId(String tisId);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/CollegeService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/CollegeService.java
@@ -27,4 +27,10 @@ import uk.nhs.hee.tis.trainee.reference.model.College;
 public interface CollegeService {
 
   List<College> getCollege();
+
+  College updateCollege(College college);
+
+  College createCollege(College college);
+
+  void deleteCollege(String tisId);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/GenderService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/GenderService.java
@@ -27,4 +27,10 @@ import uk.nhs.hee.tis.trainee.reference.model.Gender;
 public interface GenderService {
 
   List<Gender> getGender();
+
+  Gender updateGender(Gender gender);
+
+  Gender createGender(Gender gender);
+
+  void deleteGender(String tisId);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/GradeService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/GradeService.java
@@ -27,4 +27,10 @@ import uk.nhs.hee.tis.trainee.reference.model.Grade;
 public interface GradeService {
 
   List<Grade> getAllGrades();
+
+  Grade updateGrade(Grade grade);
+
+  Grade createGrade(Grade grade);
+
+  void deleteGrade(String tisId);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/ImmigrationStatusService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/ImmigrationStatusService.java
@@ -26,4 +26,10 @@ import uk.nhs.hee.tis.trainee.reference.model.ImmigrationStatus;
 public interface ImmigrationStatusService {
 
   List<ImmigrationStatus> getImmigrationStatus();
+
+  ImmigrationStatus updateImmigrationStatus(ImmigrationStatus immigrationStatus);
+
+  ImmigrationStatus createImmigrationStatus(ImmigrationStatus immigrationStatus);
+
+  void deleteImmigrationStatus(String tisId);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeService.java
@@ -27,4 +27,10 @@ import uk.nhs.hee.tis.trainee.reference.model.LocalOffice;
 public interface LocalOfficeService {
 
   List<LocalOffice> getLocalOffice();
+
+  LocalOffice updateLocalOffice(LocalOffice localOffice);
+
+  LocalOffice createLocalOffice(LocalOffice localOffice);
+
+  void deleteLocalOffice(String tisId);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/impl/CollegeServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/impl/CollegeServiceImpl.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.trainee.reference.service.impl;
 
 import java.util.List;
 import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.reference.mapper.CollegeMapper;
 import uk.nhs.hee.tis.trainee.reference.model.College;
 import uk.nhs.hee.tis.trainee.reference.repository.CollegeRepository;
 import uk.nhs.hee.tis.trainee.reference.service.CollegeService;
@@ -30,13 +31,43 @@ import uk.nhs.hee.tis.trainee.reference.service.CollegeService;
 @Service
 public class CollegeServiceImpl implements CollegeService {
 
-  CollegeRepository collegeRepository;
+  private final CollegeRepository repository;
+  private final CollegeMapper mapper;
 
-  public CollegeServiceImpl(CollegeRepository collegeRepository) {
-    this.collegeRepository = collegeRepository;
+  public CollegeServiceImpl(CollegeRepository repository, CollegeMapper mapper) {
+    this.repository = repository;
+    this.mapper = mapper;
   }
 
   public List<College> getCollege() {
-    return collegeRepository.findAll();
+    return repository.findAll();
+  }
+
+  @Override
+  public College updateCollege(College college) {
+    College persistedCollege = repository.findByTisId(college.getTisId());
+
+    if (persistedCollege == null) {
+      return createCollege(college);
+    }
+
+    persistedCollege = mapper.update(persistedCollege, college);
+    return repository.save(persistedCollege);
+  }
+
+  @Override
+  public College createCollege(College college) {
+    College persistedCollege = repository.findByTisId(college.getTisId());
+
+    if (persistedCollege != null) {
+      return updateCollege(college);
+    }
+
+    return repository.insert(college);
+  }
+
+  @Override
+  public void deleteCollege(String tisId) {
+    repository.deleteByTisId(tisId);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/impl/GenderServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/impl/GenderServiceImpl.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.trainee.reference.service.impl;
 
 import java.util.List;
 import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.reference.mapper.GenderMapper;
 import uk.nhs.hee.tis.trainee.reference.model.Gender;
 import uk.nhs.hee.tis.trainee.reference.repository.GenderRepository;
 import uk.nhs.hee.tis.trainee.reference.service.GenderService;
@@ -30,13 +31,43 @@ import uk.nhs.hee.tis.trainee.reference.service.GenderService;
 @Service
 public class GenderServiceImpl implements GenderService {
 
-  GenderRepository genderRepository;
+  private final GenderRepository repository;
+  private final GenderMapper mapper;
 
-  public GenderServiceImpl(GenderRepository genderRepository) {
-    this.genderRepository = genderRepository;
+  public GenderServiceImpl(GenderRepository repository, GenderMapper mapper) {
+    this.repository = repository;
+    this.mapper = mapper;
   }
 
   public List<Gender> getGender() {
-    return genderRepository.findAll();
+    return repository.findAll();
+  }
+
+  @Override
+  public Gender updateGender(Gender gender) {
+    Gender persistedGender = repository.findByTisId(gender.getTisId());
+
+    if (persistedGender == null) {
+      return createGender(gender);
+    }
+
+    persistedGender = mapper.update(persistedGender, gender);
+    return repository.save(persistedGender);
+  }
+
+  @Override
+  public Gender createGender(Gender gender) {
+    Gender persistedGender = repository.findByTisId(gender.getTisId());
+
+    if (persistedGender != null) {
+      return updateGender(gender);
+    }
+
+    return repository.insert(gender);
+  }
+
+  @Override
+  public void deleteGender(String tisId) {
+    repository.deleteByTisId(tisId);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/impl/GradeServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/impl/GradeServiceImpl.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.trainee.reference.service.impl;
 
 import java.util.List;
 import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.reference.mapper.GradeMapper;
 import uk.nhs.hee.tis.trainee.reference.model.Grade;
 import uk.nhs.hee.tis.trainee.reference.repository.GradeRepository;
 import uk.nhs.hee.tis.trainee.reference.service.GradeService;
@@ -30,14 +31,44 @@ import uk.nhs.hee.tis.trainee.reference.service.GradeService;
 @Service
 public class GradeServiceImpl implements GradeService {
 
-  GradeRepository gradeRepository;
+  private final GradeRepository repository;
+  private final GradeMapper mapper;
 
-  public GradeServiceImpl(GradeRepository gradeRepository) {
-    this.gradeRepository = gradeRepository;
+  public GradeServiceImpl(GradeRepository repository, GradeMapper mapper) {
+    this.repository = repository;
+    this.mapper = mapper;
   }
 
   @Override
   public List<Grade> getAllGrades() {
-    return gradeRepository.findAll();
+    return repository.findAll();
+  }
+
+  @Override
+  public Grade updateGrade(Grade grade) {
+    Grade persistedGrade = repository.findByTisId(grade.getTisId());
+
+    if (persistedGrade == null) {
+      return createGrade(grade);
+    }
+
+    persistedGrade = mapper.update(persistedGrade, grade);
+    return repository.save(persistedGrade);
+  }
+
+  @Override
+  public Grade createGrade(Grade grade) {
+    Grade persistedGrade = repository.findByTisId(grade.getTisId());
+
+    if (persistedGrade != null) {
+      return updateGrade(grade);
+    }
+
+    return repository.insert(grade);
+  }
+
+  @Override
+  public void deleteGrade(String tisId) {
+    repository.deleteByTisId(tisId);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/impl/ImmigrationStatusServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/impl/ImmigrationStatusServiceImpl.java
@@ -22,6 +22,7 @@ package uk.nhs.hee.tis.trainee.reference.service.impl;
 
 import java.util.List;
 import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.reference.mapper.ImmigrationStatusMapper;
 import uk.nhs.hee.tis.trainee.reference.model.ImmigrationStatus;
 import uk.nhs.hee.tis.trainee.reference.repository.ImmigrationStatusRepository;
 import uk.nhs.hee.tis.trainee.reference.service.ImmigrationStatusService;
@@ -29,13 +30,46 @@ import uk.nhs.hee.tis.trainee.reference.service.ImmigrationStatusService;
 @Service
 public class ImmigrationStatusServiceImpl implements ImmigrationStatusService {
 
-  ImmigrationStatusRepository immigrationStatusRepository;
+  private final ImmigrationStatusRepository repository;
+  private final ImmigrationStatusMapper mapper;
 
-  public ImmigrationStatusServiceImpl(ImmigrationStatusRepository immigrationStatusRepository) {
-    this.immigrationStatusRepository = immigrationStatusRepository;
+  public ImmigrationStatusServiceImpl(ImmigrationStatusRepository repository,
+      ImmigrationStatusMapper mapper) {
+    this.repository = repository;
+    this.mapper = mapper;
   }
 
   public List<ImmigrationStatus> getImmigrationStatus() {
-    return immigrationStatusRepository.findAll();
+    return repository.findAll();
+  }
+
+  @Override
+  public ImmigrationStatus updateImmigrationStatus(ImmigrationStatus immigrationStatus) {
+    ImmigrationStatus persistedImmigrationStatus = repository
+        .findByTisId(immigrationStatus.getTisId());
+
+    if (persistedImmigrationStatus == null) {
+      return createImmigrationStatus(immigrationStatus);
+    }
+
+    persistedImmigrationStatus = mapper.update(persistedImmigrationStatus, immigrationStatus);
+    return repository.save(persistedImmigrationStatus);
+  }
+
+  @Override
+  public ImmigrationStatus createImmigrationStatus(ImmigrationStatus immigrationStatus) {
+    ImmigrationStatus persistedImmigrationStatus = repository
+        .findByTisId(immigrationStatus.getTisId());
+
+    if (persistedImmigrationStatus != null) {
+      return updateImmigrationStatus(immigrationStatus);
+    }
+
+    return repository.insert(immigrationStatus);
+  }
+
+  @Override
+  public void deleteImmigrationStatus(String tisId) {
+    repository.deleteByTisId(tisId);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/impl/LocalOfficeServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/impl/LocalOfficeServiceImpl.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.trainee.reference.service.impl;
 
 import java.util.List;
 import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.reference.mapper.LocalOfficeMapper;
 import uk.nhs.hee.tis.trainee.reference.model.LocalOffice;
 import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeRepository;
 import uk.nhs.hee.tis.trainee.reference.service.LocalOfficeService;
@@ -30,13 +31,43 @@ import uk.nhs.hee.tis.trainee.reference.service.LocalOfficeService;
 @Service
 public class LocalOfficeServiceImpl implements LocalOfficeService {
 
-  LocalOfficeRepository localOfficeRepository;
+  private final LocalOfficeRepository repository;
+  private final LocalOfficeMapper mapper;
 
-  public LocalOfficeServiceImpl(LocalOfficeRepository localOfficeRepository) {
-    this.localOfficeRepository = localOfficeRepository;
+  public LocalOfficeServiceImpl(LocalOfficeRepository repository, LocalOfficeMapper mapper) {
+    this.repository = repository;
+    this.mapper = mapper;
   }
 
   public List<LocalOffice> getLocalOffice() {
-    return localOfficeRepository.findAll();
+    return repository.findAll();
+  }
+
+  @Override
+  public LocalOffice updateLocalOffice(LocalOffice localOffice) {
+    LocalOffice persistedLocalOffice = repository.findByTisId(localOffice.getTisId());
+
+    if (persistedLocalOffice == null) {
+      return createLocalOffice(localOffice);
+    }
+
+    persistedLocalOffice = mapper.update(persistedLocalOffice, localOffice);
+    return repository.save(persistedLocalOffice);
+  }
+
+  @Override
+  public LocalOffice createLocalOffice(LocalOffice localOffice) {
+    LocalOffice persistedLocalOffice = repository.findByTisId(localOffice.getTisId());
+
+    if (persistedLocalOffice != null) {
+      return updateLocalOffice(localOffice);
+    }
+
+    return repository.insert(localOffice);
+  }
+
+  @Override
+  public void deleteLocalOffice(String tisId) {
+    repository.deleteByTisId(tisId);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/GradeResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/GradeResourceTest.java
@@ -57,7 +57,7 @@ import uk.nhs.hee.tis.trainee.reference.service.GradeService;
 @ContextConfiguration(classes = {GradeMapper.class})
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(GradeResource.class)
-public class GradeResourceTest {
+class GradeResourceTest {
 
   private static final String DEFAULT_ID_1 = "DEFAULT_ID_1";
   private static final String DEFAULT_ID_2 = "DEFAULT_ID_2";
@@ -86,7 +86,7 @@ public class GradeResourceTest {
    * Set up mocks before each test.
    */
   @BeforeEach
-  public void setup() {
+  void setup() {
     GradeMapper mapper = Mappers.getMapper(GradeMapper.class);
     GradeResource gradeResource = new GradeResource(gradeServiceMock, mapper);
     mockMvc = MockMvcBuilders.standaloneSetup(gradeResource)
@@ -98,7 +98,7 @@ public class GradeResourceTest {
    * Set up data.
    */
   @BeforeEach
-  public void initData() {
+  void initData() {
     grade1 = new Grade();
     grade1.setId(DEFAULT_ID_1);
     grade1.setTisId(DEFAULT_TIS_ID_1);

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/ImmigrationStatusResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/ImmigrationStatusResourceTest.java
@@ -130,7 +130,7 @@ class ImmigrationStatusResourceTest {
     when(immigrationStatusServiceMock.createImmigrationStatus(immigrationStatus1))
         .thenReturn(immigrationStatus1);
 
-    mockMvc.perform(post("/api/immigrationStatus")
+    mockMvc.perform(post("/api/immigration-status")
         .content(mapper.writeValueAsBytes(immigrationStatus1))
         .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isCreated())
@@ -145,7 +145,7 @@ class ImmigrationStatusResourceTest {
     when(immigrationStatusServiceMock.updateImmigrationStatus(immigrationStatus1))
         .thenReturn(immigrationStatus1);
 
-    mockMvc.perform(put("/api/immigrationStatus")
+    mockMvc.perform(put("/api/immigration-status")
         .content(mapper.writeValueAsBytes(immigrationStatus1))
         .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
@@ -157,7 +157,7 @@ class ImmigrationStatusResourceTest {
 
   @Test
   void testDeleteImmigrationStatus() throws Exception {
-    mockMvc.perform(delete("/api/immigrationStatus/{tisId}", DEFAULT_TIS_ID_1)
+    mockMvc.perform(delete("/api/immigration-status/{tisId}", DEFAULT_TIS_ID_1)
         .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isNoContent())
         .andExpect(jsonPath("$").doesNotExist());

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeResourceTest.java
@@ -131,7 +131,7 @@ class LocalOfficeResourceTest {
   void testCreateLocalOffice() throws Exception {
     when(localOfficeServiceMock.createLocalOffice(localOffice1)).thenReturn(localOffice1);
 
-    mockMvc.perform(post("/api/localOffice")
+    mockMvc.perform(post("/api/local-office")
         .content(mapper.writeValueAsBytes(localOffice1))
         .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isCreated())
@@ -145,7 +145,7 @@ class LocalOfficeResourceTest {
   void testUpdateLocalOffice() throws Exception {
     when(localOfficeServiceMock.updateLocalOffice(localOffice1)).thenReturn(localOffice1);
 
-    mockMvc.perform(put("/api/localOffice")
+    mockMvc.perform(put("/api/local-office")
         .content(mapper.writeValueAsBytes(localOffice1))
         .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
@@ -157,7 +157,7 @@ class LocalOfficeResourceTest {
 
   @Test
   void testDeleteLocalOffice() throws Exception {
-    mockMvc.perform(delete("/api/localOffice/{tisId}", DEFAULT_TIS_ID_1)
+    mockMvc.perform(delete("/api/local-office/{tisId}", DEFAULT_TIS_ID_1)
         .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isNoContent())
         .andExpect(jsonPath("$").doesNotExist());

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/GenderServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/GenderServiceImplTest.java
@@ -21,6 +21,11 @@
 
 package uk.nhs.hee.tis.trainee.reference.service;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -30,15 +35,16 @@ import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
+import org.mapstruct.factory.Mappers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.trainee.reference.mapper.GenderMapper;
 import uk.nhs.hee.tis.trainee.reference.model.Gender;
 import uk.nhs.hee.tis.trainee.reference.repository.GenderRepository;
 import uk.nhs.hee.tis.trainee.reference.service.impl.GenderServiceImpl;
 
 @ExtendWith(MockitoExtension.class)
-public class GenderServiceImplTest {
+class GenderServiceImplTest {
 
   private static final String DEFAULT_ID_1 = "DEFAULT_ID_1";
   private static final String DEFAULT_ID_2 = "DEFAULT_ID_2";
@@ -49,11 +55,10 @@ public class GenderServiceImplTest {
   private static final String DEFAULT_LABEL_1 = "Male";
   private static final String DEFAULT_LABEL_2 = "Female";
 
-  @InjectMocks
-  private GenderServiceImpl genderServiceImpl;
+  private GenderServiceImpl service;
 
   @Mock
-  private GenderRepository genderRepositoryMock;
+  private GenderRepository repository;
 
   private Gender gender1;
   private Gender gender2;
@@ -62,7 +67,9 @@ public class GenderServiceImplTest {
    * Set up data.
    */
   @BeforeEach
-  public void initData() {
+  void initData() {
+    service = new GenderServiceImpl(repository, Mappers.getMapper(GenderMapper.class));
+
     gender1 = new Gender();
     gender1.setId(DEFAULT_ID_1);
     gender1.setTisId(DEFAULT_TIS_ID_1);
@@ -75,15 +82,70 @@ public class GenderServiceImplTest {
   }
 
   @Test
-  public void getAllGendersShouldReturnAllGenders() {
+  void getAllGendersShouldReturnAllGenders() {
     List<Gender> genders = new ArrayList<>();
     genders.add(gender1);
     genders.add(gender2);
-    when(genderRepositoryMock.findAll()).thenReturn(genders);
-    List<Gender> allGenders = genderServiceImpl.getGender();
+    when(repository.findAll()).thenReturn(genders);
+    List<Gender> allGenders = service.getGender();
     MatcherAssert.assertThat("The size of returned gender list do not match the expected value",
         allGenders.size(), CoreMatchers.equalTo(genders.size()));
     MatcherAssert.assertThat("The returned gender list doesn't not contain the expected gender",
         allGenders, CoreMatchers.hasItem(gender1));
+  }
+
+  @Test
+  void createGenderShouldCreateGenderWhenNewTisId() {
+    when(repository.findByTisId(DEFAULT_TIS_ID_2)).thenReturn(null);
+    when(repository.insert(any(Gender.class))).thenAnswer(returnsFirstArg());
+
+    Gender gender = service.createGender(gender2);
+
+    assertThat("Unexpected id.", gender.getId(), is(DEFAULT_ID_2));
+    assertThat("Unexpected TIS id.", gender.getTisId(), is(DEFAULT_TIS_ID_2));
+    assertThat("Unexpected label.", gender.getLabel(), is(DEFAULT_LABEL_2));
+  }
+
+  @Test
+  void createGenderShouldUpdateGenderWhenExistingTisId() {
+    when(repository.findByTisId(DEFAULT_TIS_ID_2)).thenReturn(gender1);
+    when(repository.save(any())).thenAnswer(returnsFirstArg());
+
+    Gender gender = service.createGender(gender2);
+
+    assertThat("Unexpected id.", gender.getId(), is(DEFAULT_ID_1));
+    assertThat("Unexpected TIS id.", gender.getTisId(), is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected label.", gender.getLabel(), is(DEFAULT_LABEL_2));
+  }
+
+  @Test
+  void updateGenderShouldCreateGenderWhenNewTisId() {
+    when(repository.findByTisId(DEFAULT_TIS_ID_2)).thenReturn(null);
+    when(repository.insert(any(Gender.class))).thenAnswer(returnsFirstArg());
+
+    Gender gender = service.updateGender(gender2);
+
+    assertThat("Unexpected id.", gender.getId(), is(DEFAULT_ID_2));
+    assertThat("Unexpected TIS id.", gender.getTisId(), is(DEFAULT_TIS_ID_2));
+    assertThat("Unexpected label.", gender.getLabel(), is(DEFAULT_LABEL_2));
+  }
+
+  @Test
+  void updateGenderShouldUpdateGenderWhenExistingTisId() {
+    when(repository.findByTisId(DEFAULT_TIS_ID_2)).thenReturn(gender1);
+    when(repository.save(any())).thenAnswer(returnsFirstArg());
+
+    Gender gender = service.updateGender(gender2);
+
+    assertThat("Unexpected id.", gender.getId(), is(DEFAULT_ID_1));
+    assertThat("Unexpected TIS id.", gender.getTisId(), is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected label.", gender.getLabel(), is(DEFAULT_LABEL_2));
+  }
+
+  @Test
+  void shouldDeleteGendersByTisId() {
+    service.deleteGender(DEFAULT_TIS_ID_1);
+
+    verify(repository).deleteByTisId(DEFAULT_TIS_ID_1);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/GradeServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/GradeServiceImplTest.java
@@ -43,7 +43,7 @@ import uk.nhs.hee.tis.trainee.reference.repository.GradeRepository;
 import uk.nhs.hee.tis.trainee.reference.service.impl.GradeServiceImpl;
 
 @ExtendWith(MockitoExtension.class)
-public class GradeServiceImplTest {
+class GradeServiceImplTest {
 
   private static final String DEFAULT_ID_1 = "DEFAULT_ID_1";
   private static final String DEFAULT_ID_2 = "DEFAULT_ID_2";


### PR DESCRIPTION
Add the endpoints needed to synchronize Grades, POST and PUT should call
each other if the existing data calls for it. This is so that an insert
or update from the CDC is always synced in to MongoDB properly, even if
TIS and SS get out of sync.

TISNEW-4307