### PR TITLE
chore: Update cloudwatch metrics config

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,10 +1,11 @@
 cloud:
   aws:
+    credentials:
+      use-default-aws-credentials-chain: true
+    region:
+      use-default-aws-region-chain: true
     stack:
       auto: ${ENABLE_CLOUDWATCH_METRICS:false}
-    region:
-      auto: false
-      static: eu-west-2
 
 management:
   metrics:


### PR DESCRIPTION
The configuration is attempting to connect to an EC2 endpoint, enable
default credentials and region chain to try and get it working within
ECS.

TIS21-1060