### PR TITLE
fix: Use label for DBC instead of name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.2.0"
+version = "0.2.1"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/DbcDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/DbcDto.java
@@ -31,5 +31,5 @@ public class DbcDto {
 
   private String id;
   private String tisId;
-  private String name;
+  private String label;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/model/Dbc.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/model/Dbc.java
@@ -35,5 +35,5 @@ public class Dbc {
 
   @Indexed(unique = true)
   private String tisId;
-  private String name;
+  private String label;
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/DbcResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/DbcResourceTest.java
@@ -65,8 +65,8 @@ class DbcResourceTest {
   private static final String DEFAULT_TIS_ID_1 = "1";
   private static final String DEFAULT_TIS_ID_2 = "2";
 
-  private static final String DEFAULT_NAME_1 = "Health Education England East of England";
-  private static final String DEFAULT_NAME_2 =
+  private static final String DEFAULT_LABEL_1 = "Health Education England East of England";
+  private static final String DEFAULT_LABEL_2 =
       "Northern Ireland Medical and Dental Training Agency";
 
   @Autowired
@@ -104,12 +104,12 @@ class DbcResourceTest {
     dbc1 = new Dbc();
     dbc1.setId(DEFAULT_ID_1);
     dbc1.setTisId(DEFAULT_TIS_ID_1);
-    dbc1.setName(DEFAULT_NAME_1);
+    dbc1.setLabel(DEFAULT_LABEL_1);
 
     dbc2 = new Dbc();
     dbc2.setId(DEFAULT_ID_2);
     dbc2.setTisId(DEFAULT_TIS_ID_2);
-    dbc2.setName(DEFAULT_NAME_2);
+    dbc2.setLabel(DEFAULT_LABEL_2);
   }
 
   @Test
@@ -138,7 +138,7 @@ class DbcResourceTest {
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value(is(DEFAULT_ID_1)))
         .andExpect(jsonPath("$.tisId").value(is(DEFAULT_TIS_ID_1)))
-        .andExpect(jsonPath("$.name").value(is(DEFAULT_NAME_1)));
+        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_1)));
   }
 
   @Test
@@ -152,7 +152,7 @@ class DbcResourceTest {
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value(is(DEFAULT_ID_1)))
         .andExpect(jsonPath("$.tisId").value(is(DEFAULT_TIS_ID_1)))
-        .andExpect(jsonPath("$.name").value(is(DEFAULT_NAME_1)));
+        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_1)));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/DbcServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/DbcServiceImplTest.java
@@ -75,12 +75,12 @@ class DbcServiceImplTest {
     dbc1 = new Dbc();
     dbc1.setId(DEFAULT_ID_1);
     dbc1.setTisId(DEFAULT_TIS_ID_1);
-    dbc1.setName(DEFAULT_NAME_1);
+    dbc1.setLabel(DEFAULT_NAME_1);
 
     dbc2 = new Dbc();
     dbc2.setId(DEFAULT_ID_2);
     dbc2.setTisId(DEFAULT_TIS_ID_2);
-    dbc2.setName(DEFAULT_NAME_2);
+    dbc2.setLabel(DEFAULT_NAME_2);
   }
 
   @Test
@@ -107,7 +107,7 @@ class DbcServiceImplTest {
 
     assertThat("Unexpected id.", dbc.getId(), is(DEFAULT_ID_2));
     assertThat("Unexpected TIS id.", dbc.getTisId(), is(DEFAULT_TIS_ID_2));
-    assertThat("Unexpected name.", dbc.getName(), is(DEFAULT_NAME_2));
+    assertThat("Unexpected name.", dbc.getLabel(), is(DEFAULT_NAME_2));
   }
 
   @Test
@@ -119,7 +119,7 @@ class DbcServiceImplTest {
 
     assertThat("Unexpected id.", dbc.getId(), is(DEFAULT_ID_1));
     assertThat("Unexpected TIS id.", dbc.getTisId(), is(DEFAULT_TIS_ID_1));
-    assertThat("Unexpected name.", dbc.getName(), is(DEFAULT_NAME_2));
+    assertThat("Unexpected name.", dbc.getLabel(), is(DEFAULT_NAME_2));
   }
 
   @Test
@@ -131,7 +131,7 @@ class DbcServiceImplTest {
 
     assertThat("Unexpected id.", dbc.getId(), is(DEFAULT_ID_2));
     assertThat("Unexpected TIS id.", dbc.getTisId(), is(DEFAULT_TIS_ID_2));
-    assertThat("Unexpected name.", dbc.getName(), is(DEFAULT_NAME_2));
+    assertThat("Unexpected name.", dbc.getLabel(), is(DEFAULT_NAME_2));
   }
 
   @Test
@@ -143,7 +143,7 @@ class DbcServiceImplTest {
 
     assertThat("Unexpected id.", dbc.getId(), is(DEFAULT_ID_1));
     assertThat("Unexpected TIS id.", dbc.getTisId(), is(DEFAULT_TIS_ID_1));
-    assertThat("Unexpected name.", dbc.getName(), is(DEFAULT_NAME_2));
+    assertThat("Unexpected name.", dbc.getLabel(), is(DEFAULT_NAME_2));
   }
 
   @Test


### PR DESCRIPTION
The name value is converted to label in tis-trainee-sync, so the DBC
entity/dto should use label instead of name. The same conversion happens
for College.

TIS21-1140