### PR TITLE
Fix/make curriculum validator correctly validate and add tests for curriculum validator

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/CurriculumDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/CurriculumDto.java
@@ -31,4 +31,6 @@ public class CurriculumDto {
   private String id;
   private String tisId;
   private String label;
+  private String code;
+  private Status status;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/CurriculumDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/CurriculumDto.java
@@ -31,6 +31,6 @@ public class CurriculumDto {
   private String id;
   private String tisId;
   private String label;
-  private String code;
+  private String curriculumSubType;
   private Status status;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidator.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidator.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.trainee.reference.dto.validator;
 
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.reference.dto.CurriculumDto;
+import uk.nhs.hee.tis.trainee.reference.dto.Status;
 
 /**
  * A validator for {@link CurriculumDto}.
@@ -38,6 +39,6 @@ public class CurriculumValidator implements ReferenceValidator<CurriculumDto> {
    */
   @Override
   public boolean isValid(CurriculumDto dto) {
-    return true;
+    return dto.getStatus() == Status.CURRENT && dto.getCode().equals("MEDICAL_CURRICULUM");
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidator.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidator.java
@@ -39,6 +39,7 @@ public class CurriculumValidator implements ReferenceValidator<CurriculumDto> {
    */
   @Override
   public boolean isValid(CurriculumDto dto) {
-    return dto.getStatus() == Status.CURRENT && dto.getCurriculumSubType().equals("MEDICAL_CURRICULUM");
+    return dto.getStatus() == Status.CURRENT
+        && dto.getCurriculumSubType().equals("MEDICAL_CURRICULUM");
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidator.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidator.java
@@ -39,6 +39,6 @@ public class CurriculumValidator implements ReferenceValidator<CurriculumDto> {
    */
   @Override
   public boolean isValid(CurriculumDto dto) {
-    return dto.getStatus() == Status.CURRENT && dto.getCode().equals("MEDICAL_CURRICULUM");
+    return dto.getStatus() == Status.CURRENT && dto.getCurriculumSubType().equals("MEDICAL_CURRICULUM");
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidatorTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidatorTest.java
@@ -41,7 +41,7 @@ class CurriculumValidatorTest {
   }
 
   @ParameterizedTest(
-      name = "Valid should be {2} when status is {0} and code is equal to {1}."
+      name = "Valid should be {2} when status is {0} and curriculumSubType is equal to {1}."
   )
   @CsvSource({
       "INACTIVE,Other,false",
@@ -49,10 +49,10 @@ class CurriculumValidatorTest {
       "CURRENT,Other,false",
       "CURRENT,MEDICAL_CURRICULUM,true"
   })
-  void shouldValidateCurriculum(Status status, String code, boolean result) {
+  void shouldValidateCurriculum(Status status, String curriculumSubType, boolean result) {
     CurriculumDto dto = new CurriculumDto();
     dto.setStatus(status);
-    dto.setCode(code);
+    dto.setCurriculumSubType(curriculumSubType);
 
     boolean valid = validator.isValid(dto);
     assertThat("Unexpected validity.", valid, is(result));

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidatorTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidatorTest.java
@@ -26,7 +26,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import uk.nhs.hee.tis.trainee.reference.dto.CurriculumDto;
+import uk.nhs.hee.tis.trainee.reference.dto.Status;
 
 class CurriculumValidatorTest {
 
@@ -37,11 +40,21 @@ class CurriculumValidatorTest {
     validator = new CurriculumValidator();
   }
 
-  @Test
-  void shouldValidateCurriculum() {
+  @ParameterizedTest(
+      name = "Valid should be {2} when status is {0} and code is equal to {1}."
+  )
+  @CsvSource({
+      "INACTIVE,Other,false",
+      "INACTIVE,MEDICAL_CURRICULUM,false",
+      "CURRENT,Other,false",
+      "CURRENT,MEDICAL_CURRICULUM,true"
+  })
+  void shouldValidateCurriculum(Status status, String code, boolean result) {
     CurriculumDto dto = new CurriculumDto();
+    dto.setStatus(status);
+    dto.setCode(code);
 
     boolean valid = validator.isValid(dto);
-    assertThat("Unexpected validity.", valid, is(true));
+    assertThat("Unexpected validity.", valid, is(result));
   }
 }


### PR DESCRIPTION
fix: changed CurriculumValidator to return true if Status == CURRENT and Code equals 'MEDICAL_CURRICULUM'.

test: updated the CurriculumValidatorTest so that it tests the CurriculumValidator using Status and Code.

TIS21-1397