### PR TITLE
fix: NPE validating a curriculum with no subtype

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.3.0"
+version = "0.3.1"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidator.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidator.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.reference.dto.validator;
 
+import java.util.Objects;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.reference.dto.CurriculumDto;
 import uk.nhs.hee.tis.trainee.reference.dto.Status;
@@ -40,6 +41,6 @@ public class CurriculumValidator implements ReferenceValidator<CurriculumDto> {
   @Override
   public boolean isValid(CurriculumDto dto) {
     return dto.getStatus() == Status.CURRENT
-        && dto.getCurriculumSubType().equals("MEDICAL_CURRICULUM");
+        && Objects.equals(dto.getCurriculumSubType(), ("MEDICAL_CURRICULUM"));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidatorTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidatorTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import uk.nhs.hee.tis.trainee.reference.dto.CurriculumDto;
@@ -47,7 +46,10 @@ class CurriculumValidatorTest {
       "INACTIVE,Other,false",
       "INACTIVE,MEDICAL_CURRICULUM,false",
       "CURRENT,Other,false",
-      "CURRENT,MEDICAL_CURRICULUM,true"
+      "CURRENT,MEDICAL_CURRICULUM,true",
+      "CURRENT,,false",
+      ",MEDICAL_CURRICULUM,false",
+      ",,false"
   })
   void shouldValidateCurriculum(Status status, String curriculumSubType, boolean result) {
     CurriculumDto dto = new CurriculumDto();


### PR DESCRIPTION
The equality check causes a NullPointerException when the curriculum's
sub type is null. As this is a valid state for the data it should be
properly handled as a validation failure without an exception.

TIS21-1397