### PR TITLE
fix: Add DeclarationType values automatically

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.3.2"
+version = "0.3.3"
 sourceCompatibility = "11"
 
 configurations {
@@ -40,6 +40,11 @@ dependencies {
   ext.mapStructVersion = "1.4.2.Final"
   implementation "org.mapstruct:mapstruct:$mapStructVersion"
   annotationProcessor "org.mapstruct:mapstruct-processor:$mapStructVersion"
+
+  // Mongock
+  ext.mongockVersion = "4.3.8"
+  implementation "com.github.cloudyrock.mongock:mongock-spring-v5:${mongockVersion}"
+  implementation "com.github.cloudyrock.mongock:mongodb-springdata-v3-driver:${mongockVersion}"
 
   // Sentry reporting
   implementation "io.sentry:sentry-spring-boot-starter:4.3.0"

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/TisTraineeReferenceApplication.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/TisTraineeReferenceApplication.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.trainee.reference;
 
 import static springfox.documentation.builders.PathSelectors.regex;
 
+import com.github.cloudyrock.spring.v5.EnableMongock;
 import java.util.Collections;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -33,6 +34,7 @@ import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
+@EnableMongock
 @SpringBootApplication
 @EnableSwagger2
 public class TisTraineeReferenceApplication {

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/changelog/DeclarationTypeChangeLog.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/changelog/DeclarationTypeChangeLog.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.changelog;
+
+import com.github.cloudyrock.mongock.ChangeLog;
+import com.github.cloudyrock.mongock.ChangeSet;
+import com.github.cloudyrock.mongock.driver.mongodb.springdata.v3.decorator.impl.MongockTemplate;
+import java.util.Set;
+import uk.nhs.hee.tis.trainee.reference.model.DeclarationType;
+
+@ChangeLog
+public class DeclarationTypeChangeLog {
+
+  @ChangeSet(order = "001", id = "insertInitialDeclarationTypes", author = "")
+  public void insertInitialDeclarationTypes(MongockTemplate mongockTemplate) {
+    DeclarationType significantEvent = new DeclarationType();
+    significantEvent.setLabel("Significant event");
+
+    DeclarationType complaint = new DeclarationType();
+    complaint.setLabel("Complaint");
+
+    DeclarationType otherInvestigation = new DeclarationType();
+    otherInvestigation.setLabel("Other investigation");
+
+    mongockTemplate.insertAll(Set.of(significantEvent, complaint, otherInvestigation));
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+mongock:
+  change-logs-scan-package: uk.nhs.hee.tis.trainee.reference.changelog
+
 server:
   port: 8205
   servlet:

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/changelog/DeclarationTypeChangeLogTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/changelog/DeclarationTypeChangeLogTest.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.changelog;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.github.cloudyrock.mongock.driver.mongodb.springdata.v3.decorator.impl.MongockTemplate;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.trainee.reference.model.DeclarationType;
+
+@ExtendWith(MockitoExtension.class)
+class DeclarationTypeChangeLogTest {
+
+  private DeclarationTypeChangeLog changeLog;
+
+  @Mock
+  private MongockTemplate template;
+
+  @BeforeEach
+  void setUp() {
+    changeLog = new DeclarationTypeChangeLog();
+  }
+
+  @Test
+  void shouldAddInitialDeclarationTypes() {
+    changeLog.insertInitialDeclarationTypes(template);
+
+    ArgumentCaptor<Collection> collectionCaptor = ArgumentCaptor.forClass(Collection.class);
+    verify(template).insertAll(collectionCaptor.capture());
+
+    Collection<?> declarationTypes = collectionCaptor.getValue();
+    assertThat("Unexpected collection size.", declarationTypes.size(), is(3));
+    Set<String> declarationTypeValues = declarationTypes.stream()
+        .filter(dt -> dt instanceof DeclarationType)
+        .map(dt -> ((DeclarationType) dt).getLabel())
+        .collect(Collectors.toSet());
+
+    assertThat("Unexpected number of declaration type values.", declarationTypeValues.size(),
+        is(3));
+    assertThat("Unexpected declaration type values.", declarationTypeValues,
+        hasItems("Significant event", "Complaint", "Other investigation"));
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,2 @@
+mongock:
+  enabled: false


### PR DESCRIPTION
The DeclarationType reference table is not populated automatically and
requires manual intervention. Use Mongock to insert the missing data
automatically.

TIS21-1456