### PR TITLE
feat: Add SUB_SPECIALTY curricula to validator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.4.4"
+version = "0.4.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.3.4"
+version = "0.4.4"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidator.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidator.java
@@ -41,6 +41,7 @@ public class CurriculumValidator implements ReferenceValidator<CurriculumDto> {
   @Override
   public boolean isValid(CurriculumDto dto) {
     return dto.getStatus() == Status.CURRENT
-        && Objects.equals(dto.getCurriculumSubType(), ("MEDICAL_CURRICULUM"));
+        && Objects.equals(dto.getCurriculumSubType(), ("MEDICAL_CURRICULUM"))
+        || Objects.equals(dto.getCurriculumSubType(), ("SUB_SPECIALTY"));
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidator.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidator.java
@@ -41,7 +41,7 @@ public class CurriculumValidator implements ReferenceValidator<CurriculumDto> {
   @Override
   public boolean isValid(CurriculumDto dto) {
     return dto.getStatus() == Status.CURRENT
-        && Objects.equals(dto.getCurriculumSubType(), ("MEDICAL_CURRICULUM"))
-        || Objects.equals(dto.getCurriculumSubType(), ("SUB_SPECIALTY"));
+        && (Objects.equals(dto.getCurriculumSubType(), ("MEDICAL_CURRICULUM"))
+        || Objects.equals(dto.getCurriculumSubType(), ("SUB_SPECIALTY")));
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/CurriculumMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/CurriculumMapper.java
@@ -40,6 +40,5 @@ public interface CurriculumMapper {
 
   @Mapping(target = "id", ignore = true)
   @Mapping(target = "tisId", ignore = true)
-  @Mapping(target = "curriculumSubType")
   Curriculum update(@MappingTarget Curriculum target, Curriculum source);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/CurriculumMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/CurriculumMapper.java
@@ -40,5 +40,6 @@ public interface CurriculumMapper {
 
   @Mapping(target = "id", ignore = true)
   @Mapping(target = "tisId", ignore = true)
+  @Mapping(target = "curriculumSubType", ignore = true)
   Curriculum update(@MappingTarget Curriculum target, Curriculum source);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/CurriculumMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/CurriculumMapper.java
@@ -40,6 +40,6 @@ public interface CurriculumMapper {
 
   @Mapping(target = "id", ignore = true)
   @Mapping(target = "tisId", ignore = true)
-  @Mapping(target = "curriculumSubType", ignore = true)
+  @Mapping(target = "curriculumSubType")
   Curriculum update(@MappingTarget Curriculum target, Curriculum source);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/model/Curriculum.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/model/Curriculum.java
@@ -35,4 +35,5 @@ public class Curriculum {
   @Indexed(unique = true)
   private String tisId;
   private String label;
+  private String curriculumSubType;
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/CurriculumResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/CurriculumResourceTest.java
@@ -70,6 +70,9 @@ class CurriculumResourceTest {
   private static final String DEFAULT_LABEL_1 = "GP Returner";
   private static final String DEFAULT_LABEL_2 = "Paediatrics";
 
+  private static final String DEFAULT_CURRICULUM_SUBTYPE_1 = "MEDICAL_CURRICULUM";
+  private static final String DEFAULT_CURRICULUM_SUBTYPE_2 = "SUB_SPECIALTY";
+
   @Autowired
   private MappingJackson2HttpMessageConverter jacksonMessageConverter;
 
@@ -110,16 +113,19 @@ class CurriculumResourceTest {
     dto.setId(DEFAULT_ID_1);
     dto.setTisId(DEFAULT_TIS_ID_1);
     dto.setLabel(DEFAULT_LABEL_1);
+    dto.setCurriculumSubType(DEFAULT_CURRICULUM_SUBTYPE_1);
 
     entity1 = new Curriculum();
     entity1.setId(DEFAULT_ID_1);
     entity1.setTisId(DEFAULT_TIS_ID_1);
     entity1.setLabel(DEFAULT_LABEL_1);
+    entity1.setCurriculumSubType(DEFAULT_CURRICULUM_SUBTYPE_1);
 
     entity2 = new Curriculum();
     entity2.setId(DEFAULT_ID_2);
     entity2.setTisId(DEFAULT_TIS_ID_2);
     entity2.setLabel(DEFAULT_LABEL_2);
+    entity2.setCurriculumSubType(DEFAULT_CURRICULUM_SUBTYPE_2);
   }
 
   @Test
@@ -149,7 +155,8 @@ class CurriculumResourceTest {
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value(is(DEFAULT_ID_1)))
         .andExpect(jsonPath("$.tisId").value(is(DEFAULT_TIS_ID_1)))
-        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_1)));
+        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_1)))
+        .andExpect(jsonPath("$.curriculumSubType").value(is(DEFAULT_CURRICULUM_SUBTYPE_1)));
   }
 
   @Test
@@ -178,7 +185,8 @@ class CurriculumResourceTest {
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value(is(DEFAULT_ID_1)))
         .andExpect(jsonPath("$.tisId").value(is(DEFAULT_TIS_ID_1)))
-        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_1)));
+        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_1)))
+        .andExpect(jsonPath("$.curriculumSubType").value(is(DEFAULT_CURRICULUM_SUBTYPE_1)));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidatorTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidatorTest.java
@@ -49,7 +49,8 @@ class CurriculumValidatorTest {
       "DELETE,MEDICAL_CURRICULUM,false",
       "CURRENT,Other,false",
       "CURRENT,MEDICAL_CURRICULUM,true",
-      "CURRENT,SUB_SPECIALTY, true",
+      "CURRENT,SUB_SPECIALTY,true",
+      "INACTIVE,SUB_SPECIALTY,false",
       "CURRENT,,false",
       ",MEDICAL_CURRICULUM,false",
       ",,false"

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidatorTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CurriculumValidatorTest.java
@@ -49,6 +49,7 @@ class CurriculumValidatorTest {
       "DELETE,MEDICAL_CURRICULUM,false",
       "CURRENT,Other,false",
       "CURRENT,MEDICAL_CURRICULUM,true",
+      "CURRENT,SUB_SPECIALTY, true",
       "CURRENT,,false",
       ",MEDICAL_CURRICULUM,false",
       ",,false"


### PR DESCRIPTION
Validator now checks curricula are of curriculumSubType "SUB_SPECIALTY" as well as "MEDICAL_CURRICULUM"

**TIS21-1674**: add list of subspecialties to the Form R Part A Declarations Section