### PR TITLE
feat: Add type and internal fields to DBC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.4.0"
+version = "0.5.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/api/DbcResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/api/DbcResource.java
@@ -43,8 +43,8 @@ import uk.nhs.hee.tis.trainee.reference.service.DbcService;
 @RequestMapping("/api/dbc")
 public class DbcResource {
 
-  private DbcService service;
-  private DbcMapper mapper;
+  private final DbcService service;
+  private final DbcMapper mapper;
 
   public DbcResource(DbcService service, DbcMapper mapper) {
     this.service = service;

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/DbcDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/DbcDto.java
@@ -32,4 +32,6 @@ public class DbcDto {
   private String id;
   private String tisId;
   private String label;
+  private String type;
+  private boolean internal;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/model/Dbc.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/model/Dbc.java
@@ -36,4 +36,6 @@ public class Dbc {
   @Indexed(unique = true)
   private String tisId;
   private String label;
+  private String type;
+  private boolean internal;
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/DbcResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/DbcResourceTest.java
@@ -62,12 +62,18 @@ class DbcResourceTest {
   private static final String DEFAULT_ID_1 = "DEFAULT_ID_1";
   private static final String DEFAULT_ID_2 = "DEFAULT_ID_2";
 
+  private static final boolean DEFAULT_INTERNAL_1 = true;
+  private static final boolean DEFAULT_INTERNAL_2 = false;
+
   private static final String DEFAULT_TIS_ID_1 = "1";
   private static final String DEFAULT_TIS_ID_2 = "2";
 
   private static final String DEFAULT_LABEL_1 = "Health Education England East of England";
   private static final String DEFAULT_LABEL_2 =
       "Northern Ireland Medical and Dental Training Agency";
+
+  private static final String DEFAULT_TYPE_1 = "DEFAULT_TYPE_1";
+  private static final String DEFAULT_TYPE_2 = "DEFAULT_TYPE_2";
 
   @Autowired
   private MappingJackson2HttpMessageConverter jacksonMessageConverter;
@@ -105,11 +111,15 @@ class DbcResourceTest {
     dbc1.setId(DEFAULT_ID_1);
     dbc1.setTisId(DEFAULT_TIS_ID_1);
     dbc1.setLabel(DEFAULT_LABEL_1);
+    dbc1.setType(DEFAULT_TYPE_1);
+    dbc1.setInternal(DEFAULT_INTERNAL_1);
 
     dbc2 = new Dbc();
     dbc2.setId(DEFAULT_ID_2);
     dbc2.setTisId(DEFAULT_TIS_ID_2);
     dbc2.setLabel(DEFAULT_LABEL_2);
+    dbc2.setType(DEFAULT_TYPE_2);
+    dbc2.setInternal(DEFAULT_INTERNAL_2);
   }
 
   @Test
@@ -138,21 +148,25 @@ class DbcResourceTest {
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value(is(DEFAULT_ID_1)))
         .andExpect(jsonPath("$.tisId").value(is(DEFAULT_TIS_ID_1)))
-        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_1)));
+        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_1)))
+        .andExpect(jsonPath("$.type").value(is(DEFAULT_TYPE_1)))
+        .andExpect(jsonPath("$.internal").value(is(DEFAULT_INTERNAL_1)));
   }
 
   @Test
   void testUpdateDbc() throws Exception {
-    when(dbcServiceMock.update(dbc1)).thenReturn(dbc1);
+    when(dbcServiceMock.update(dbc1)).thenReturn(dbc2);
 
     mockMvc.perform(put("/api/dbc")
         .content(mapper.writeValueAsBytes(dbc1))
         .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.id").value(is(DEFAULT_ID_1)))
-        .andExpect(jsonPath("$.tisId").value(is(DEFAULT_TIS_ID_1)))
-        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_1)));
+        .andExpect(jsonPath("$.id").value(is(DEFAULT_ID_2)))
+        .andExpect(jsonPath("$.tisId").value(is(DEFAULT_TIS_ID_2)))
+        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_2)))
+        .andExpect(jsonPath("$.type").value(is(DEFAULT_TYPE_2)))
+        .andExpect(jsonPath("$.internal").value(is(DEFAULT_INTERNAL_2)));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/DbcServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/DbcServiceTest.java
@@ -49,12 +49,18 @@ class DbcServiceTest {
   private static final String DEFAULT_ID_1 = "DEFAULT_ID_1";
   private static final String DEFAULT_ID_2 = "DEFAULT_ID_2";
 
+  private static final boolean DEFAULT_INTERNAL_1 = true;
+  private static final boolean DEFAULT_INTERNAL_2 = false;
+
   private static final String DEFAULT_TIS_ID_1 = "1";
   private static final String DEFAULT_TIS_ID_2 = "2";
 
   private static final String DEFAULT_LABEL_1 = "Health Education England East of England";
   private static final String DEFAULT_LABEL_2 =
       "Northern Ireland Medical and Dental Training Agency";
+
+  private static final String DEFAULT_TYPE_1 = "DEFAULT_TYPE_1";
+  private static final String DEFAULT_TYPE_2 = "DEFAULT_TYPE_2";
 
   private DbcService service;
 
@@ -75,11 +81,15 @@ class DbcServiceTest {
     dbc1.setId(DEFAULT_ID_1);
     dbc1.setTisId(DEFAULT_TIS_ID_1);
     dbc1.setLabel(DEFAULT_LABEL_1);
+    dbc1.setType(DEFAULT_TYPE_1);
+    dbc1.setInternal(DEFAULT_INTERNAL_1);
 
     dbc2 = new Dbc();
     dbc2.setId(DEFAULT_ID_2);
     dbc2.setTisId(DEFAULT_TIS_ID_2);
     dbc2.setLabel(DEFAULT_LABEL_2);
+    dbc2.setType(DEFAULT_TYPE_2);
+    dbc2.setInternal(DEFAULT_INTERNAL_2);
   }
 
   @Test
@@ -107,6 +117,8 @@ class DbcServiceTest {
     assertThat("Unexpected id.", dbc.getId(), is(DEFAULT_ID_2));
     assertThat("Unexpected TIS id.", dbc.getTisId(), is(DEFAULT_TIS_ID_2));
     assertThat("Unexpected label.", dbc.getLabel(), is(DEFAULT_LABEL_2));
+    assertThat("Unexpected type.", dbc.getType(), is(DEFAULT_TYPE_2));
+    assertThat("Unexpected internal flag.", dbc.isInternal(), is(DEFAULT_INTERNAL_2));
   }
 
   @Test
@@ -119,6 +131,8 @@ class DbcServiceTest {
     assertThat("Unexpected id.", dbc.getId(), is(DEFAULT_ID_1));
     assertThat("Unexpected TIS id.", dbc.getTisId(), is(DEFAULT_TIS_ID_1));
     assertThat("Unexpected label.", dbc.getLabel(), is(DEFAULT_LABEL_2));
+    assertThat("Unexpected type.", dbc.getType(), is(DEFAULT_TYPE_2));
+    assertThat("Unexpected internal flag.", dbc.isInternal(), is(DEFAULT_INTERNAL_2));
   }
 
   @Test
@@ -131,6 +145,8 @@ class DbcServiceTest {
     assertThat("Unexpected id.", dbc.getId(), is(DEFAULT_ID_2));
     assertThat("Unexpected TIS id.", dbc.getTisId(), is(DEFAULT_TIS_ID_2));
     assertThat("Unexpected label.", dbc.getLabel(), is(DEFAULT_LABEL_2));
+    assertThat("Unexpected type.", dbc.getType(), is(DEFAULT_TYPE_2));
+    assertThat("Unexpected internal flag.", dbc.isInternal(), is(DEFAULT_INTERNAL_2));
   }
 
   @Test
@@ -143,6 +159,8 @@ class DbcServiceTest {
     assertThat("Unexpected id.", dbc.getId(), is(DEFAULT_ID_1));
     assertThat("Unexpected TIS id.", dbc.getTisId(), is(DEFAULT_TIS_ID_1));
     assertThat("Unexpected label.", dbc.getLabel(), is(DEFAULT_LABEL_2));
+    assertThat("Unexpected type.", dbc.getType(), is(DEFAULT_TYPE_2));
+    assertThat("Unexpected internal flag.", dbc.isInternal(), is(DEFAULT_INTERNAL_2));
   }
 
   @Test


### PR DESCRIPTION
The DBC has had `type` and `internal` fields added to allow better
identification of the scope/context of each DBC.

TIS21-1659