### PR TITLE
chore: fix preprod deploy

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -213,7 +213,7 @@ jobs:
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: trainee-reference
+          service: ${{ github.event.repository.name }}
           cluster: trainee-preprod
           wait-for-service-stability: true
 


### PR DESCRIPTION
The service name for preprod was updated to match the expected naming
standards.

TIS21-2560