### PR TITLE
chore: remove springfox-swagger dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.5.0"
+version = "0.5.1"
 sourceCompatibility = "11"
 
 configurations {
@@ -48,11 +48,6 @@ dependencies {
 
   // Sentry reporting
   implementation "io.sentry:sentry-spring-boot-starter:5.6.1"
-
-  // Swagger
-  ext.swaggerVersion = "3.0.0"
-  implementation "io.springfox:springfox-swagger2:$swaggerVersion"
-  implementation "io.springfox:springfox-swagger-ui:$swaggerVersion"
 }
 
 checkstyle {

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/TisTraineeReferenceApplication.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/TisTraineeReferenceApplication.java
@@ -21,52 +21,15 @@
 
 package uk.nhs.hee.tis.trainee.reference;
 
-import static springfox.documentation.builders.PathSelectors.regex;
-
 import com.github.cloudyrock.spring.v5.EnableMongock;
-import java.util.Collections;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @EnableMongock
 @SpringBootApplication
-@EnableSwagger2
 public class TisTraineeReferenceApplication {
 
   public static void main(String[] args) {
     SpringApplication.run(TisTraineeReferenceApplication.class);
-  }
-
-  /**
-   * Configure swagger.
-   *
-   * @return The swagger configuration {@link Docket}.
-   */
-  @Bean
-  public Docket swaggerConfiguration() {
-    return new Docket(DocumentationType.SWAGGER_2)
-        .select()
-        .paths(regex("/api.*"))
-        .apis(RequestHandlerSelectors.basePackage("uk.nhs.hee.tis.trainee.reference"))
-        .build()
-        .apiInfo(apiDetails());
-  }
-
-  private ApiInfo apiDetails() {
-    return new ApiInfo(
-        "Trainee Reference API",
-        "The TIS-TRAINEE-REFERENCE microservice's APIs",
-        "1.0",
-        "These will be consumed by React UI or other microservices",
-        new springfox.documentation.service.Contact("Contact", "TIS Dev Team", "aaaa@hee.nhs.uk"),
-        "API Licence",
-        "TIS",
-        Collections.emptyList());
   }
 }


### PR DESCRIPTION
`springfox-swagger` is not currently compatible with the latest
Spring(Boot) versions. Given that none of our APIs are actually properly
annotated for Swagger the easiest fix for the runtime issue is to remove
the swagger dependencies.

NO-TICKET