### PR TITLE
fix: add Grade abbreviation to Grade table

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/model/Grade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/model/Grade.java
@@ -36,4 +36,5 @@ public class Grade {
   @Indexed(unique = true)
   private String tisId;
   private String label;
+  private String abbreviation;
 }


### PR DESCRIPTION
TIS21-3123