### PR TITLE
feat: log ECS metadata with X-Ray and Sentry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.1.0"
+version = "1.2.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/config/ApplicationConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/config/ApplicationConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * General application configuration beans which do not warrant their own configuration class.
+ */
+@Configuration
+public class ApplicationConfiguration {
+
+  @Bean
+  RestTemplate restTemplate(RestTemplateBuilder builder) {
+    return builder.build();
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/config/AwsXrayInterceptor.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/config/AwsXrayInterceptor.java
@@ -21,17 +21,44 @@
 
 package uk.nhs.hee.tis.trainee.reference.config;
 
+import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.spring.aop.AbstractXRayInterceptor;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.Optional;
+import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.reference.config.EcsMetadataConfiguration.EcsMetadata;
 
 @Aspect
 @Component
 @ConditionalOnExpression("!T(org.springframework.util.StringUtils)"
     + ".isEmpty('${com.amazonaws.xray.emitters.daemon-address}')")
 public class AwsXrayInterceptor extends AbstractXRayInterceptor {
+
+  private final EcsMetadata ecsMetadata;
+  private final ObjectMapper mapper;
+
+  AwsXrayInterceptor(Optional<EcsMetadata> ecsMetadata, ObjectMapper mapper) {
+    this.ecsMetadata = ecsMetadata.orElse(null);
+    this.mapper = mapper;
+  }
+
+  @Override
+  protected Map<String, Map<String, Object>> generateMetadata(ProceedingJoinPoint pjp,
+      Subsegment subsegment) {
+    Map<String, Map<String, Object>> metadata = super.generateMetadata(pjp, subsegment);
+
+    Map<String, Object> taskMetadataMap = mapper.convertValue(ecsMetadata, new TypeReference<>() {
+    });
+    metadata.put("EcsMetadata", taskMetadataMap);
+
+    return metadata;
+  }
 
   @Override
   @Pointcut(

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/config/EcsMetadataConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/config/EcsMetadataConfiguration.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import uk.nhs.hee.tis.trainee.reference.config.EcsMetadataConfiguration.EcsMetadata.ContainerMetadata;
+import uk.nhs.hee.tis.trainee.reference.config.EcsMetadataConfiguration.EcsMetadata.TaskMetadata;
+
+@Configuration
+@ConditionalOnExpression("!T(org.springframework.util.StringUtils)"
+    + ".isEmpty('${ecs.container.metadata.uri.v4:}')")
+public class EcsMetadataConfiguration {
+
+  /**
+   * Generate ECS metadata based on the ECS metadata endpoint.
+   *
+   * @param restTemplate     The rest template to call the endpoint with.
+   * @param metadataEndpoint The endpoint to call to get ECS metadata.
+   * @return The parsed ECS metadata.
+   */
+  @Bean
+  public EcsMetadata ecsMetadata(RestTemplate restTemplate,
+      @Value("${ecs.container.metadata.uri.v4}") String metadataEndpoint) {
+    ContainerMetadata containerMetadata = restTemplate.getForObject(metadataEndpoint,
+        ContainerMetadata.class);
+    TaskMetadata taskMetadata = restTemplate.getForObject(metadataEndpoint + "/task",
+        TaskMetadata.class);
+
+    return new EcsMetadata(taskMetadata, containerMetadata);
+  }
+
+  public record EcsMetadata(
+      @JsonProperty("TaskMetadata")
+      TaskMetadata taskMetadata,
+
+      @JsonProperty("ContainerMetadata")
+      ContainerMetadata containerMetadata) {
+
+    record TaskMetadata(
+        @JsonProperty("Cluster")
+        String cluster,
+
+        @JsonProperty("TaskARN")
+        String taskArn,
+
+        @JsonProperty("Family")
+        String family,
+
+        @JsonProperty("Revision")
+        String revision) {
+
+    }
+
+    record ContainerMetadata(
+
+        @JsonProperty("ContainerARN")
+        String containerArn,
+
+        @JsonProperty("LogOptions")
+        LogOptions logOptions) {
+
+      record LogOptions(
+          @JsonProperty("awslogs-group")
+          String logGroup,
+
+          @JsonProperty("awslogs-region")
+          String region,
+
+          @JsonProperty("awslogs-stream")
+          String logStream) {
+
+      }
+    }
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/config/SentryConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/config/SentryConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.config;
+
+import io.sentry.Sentry;
+import java.util.Optional;
+import javax.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+import uk.nhs.hee.tis.trainee.reference.config.EcsMetadataConfiguration.EcsMetadata;
+
+/**
+ * Additional configuration for Sentry.
+ */
+@Configuration
+public class SentryConfiguration {
+
+  private final Optional<EcsMetadata> ecsMetadata;
+
+  SentryConfiguration(Optional<EcsMetadata> ecsMetadata) {
+    this.ecsMetadata = ecsMetadata;
+  }
+
+  /**
+   * Configure the Sentry scope with additional ECS metadata.
+   */
+  @PostConstruct
+  void configureScope() {
+    ecsMetadata.ifPresent(metadata ->
+        Sentry.configureScope(scope -> scope.setContexts("EcsMetadata", metadata))
+    );
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/config/ApplicationConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/config/ApplicationConfigurationTest.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.config;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.web.client.RestTemplate;
+
+class ApplicationConfigurationTest {
+
+  private ApplicationConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    configuration = new ApplicationConfiguration();
+  }
+
+  @Test
+  void restTemplate() {
+    RestTemplateBuilder restTemplateBuilder = new RestTemplateBuilder();
+
+    RestTemplate restTemplate = configuration.restTemplate(restTemplateBuilder);
+
+    assertThat("Unexpected rest template.", restTemplate, notNullValue());
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/config/AwsXrayInterceptorTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/config/AwsXrayInterceptorTest.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.config;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.xray.entities.Subsegment;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.Optional;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.hee.tis.trainee.reference.config.EcsMetadataConfiguration.EcsMetadata;
+import uk.nhs.hee.tis.trainee.reference.config.EcsMetadataConfiguration.EcsMetadata.ContainerMetadata;
+import uk.nhs.hee.tis.trainee.reference.config.EcsMetadataConfiguration.EcsMetadata.ContainerMetadata.LogOptions;
+import uk.nhs.hee.tis.trainee.reference.config.EcsMetadataConfiguration.EcsMetadata.TaskMetadata;
+
+class AwsXrayInterceptorTest {
+
+  private ObjectMapper objectMapper;
+  private ProceedingJoinPoint pjp;
+  private Subsegment subsegment;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper();
+    subsegment = mock(Subsegment.class);
+
+    pjp = mock(ProceedingJoinPoint.class);
+    when(pjp.getTarget()).thenReturn(Object.class);
+  }
+
+  @Test
+  void shouldGenerateNullEcsMetadataWhenNotAvailable() {
+    AwsXrayInterceptor interceptor = new AwsXrayInterceptor(Optional.empty(), objectMapper);
+
+    Map<String, Map<String, Object>> metadata = interceptor.generateMetadata(pjp, subsegment);
+
+    assertThat("Unexpected X-Ray metadata.", metadata, notNullValue());
+
+    Map<String, Object> ecsMetadataMap = metadata.get("EcsMetadata");
+    assertThat("Unexpected ECS metadata.", ecsMetadataMap, nullValue());
+  }
+
+  @Test
+  void shouldGenerateEcsMetadataWhenAvailable() {
+    EcsMetadata ecsMetadata = new EcsMetadata(
+        new TaskMetadata("cluster", "taskArn", "family", "revision"),
+        new ContainerMetadata("containerArn", new LogOptions("logGroup", "region", "logStream")));
+    AwsXrayInterceptor interceptor = new AwsXrayInterceptor(Optional.of(ecsMetadata), objectMapper);
+
+    Map<String, Map<String, Object>> metadata = interceptor.generateMetadata(pjp, subsegment);
+
+    assertThat("Unexpected X-Ray metadata.", metadata, notNullValue());
+
+    Map<String, Object> ecsMetadataMap = metadata.get("EcsMetadata");
+    assertThat("Unexpected ECS metadata.", ecsMetadataMap, notNullValue());
+
+    Map<String, Object> taskMetadataMap = (Map<String, Object>) ecsMetadataMap.get("TaskMetadata");
+    assertThat("Unexpected task metadata.", taskMetadataMap, notNullValue());
+    assertThat("Unexpected cluster.", taskMetadataMap.get("Cluster"), is("cluster"));
+    assertThat("Unexpected task ARN.", taskMetadataMap.get("TaskARN"), is("taskArn"));
+    assertThat("Unexpected family.", taskMetadataMap.get("Family"), is("family"));
+
+    Map<String, Object> containerMetadataMap = (Map<String, Object>) ecsMetadataMap.get(
+        "ContainerMetadata");
+    assertThat("Unexpected container metadata.", containerMetadataMap, notNullValue());
+    assertThat("Unexpected container ARN.", containerMetadataMap.get("ContainerARN"),
+        is("containerArn"));
+
+    Map<String, Object> logOptionsMap = (Map<String, Object>) containerMetadataMap.get(
+        "LogOptions");
+    assertThat("Unexpected log options metadata.", logOptionsMap, notNullValue());
+    assertThat("Unexpected log group.", logOptionsMap.get("awslogs-group"), is("logGroup"));
+    assertThat("Unexpected log region.", logOptionsMap.get("awslogs-region"), is("region"));
+    assertThat("Unexpected log stream.", logOptionsMap.get("awslogs-stream"), is("logStream"));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/config/EcsMetadataConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/config/EcsMetadataConfigurationTest.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.config;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import uk.nhs.hee.tis.trainee.reference.config.EcsMetadataConfiguration.EcsMetadata;
+import uk.nhs.hee.tis.trainee.reference.config.EcsMetadataConfiguration.EcsMetadata.ContainerMetadata;
+import uk.nhs.hee.tis.trainee.reference.config.EcsMetadataConfiguration.EcsMetadata.ContainerMetadata.LogOptions;
+import uk.nhs.hee.tis.trainee.reference.config.EcsMetadataConfiguration.EcsMetadata.TaskMetadata;
+
+class EcsMetadataConfigurationTest {
+
+  private static final String ECS_METADATA_ENDPOINT = "https://ecs.metadata/endpoint";
+
+  private EcsMetadataConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    configuration = new EcsMetadataConfiguration();
+  }
+
+  @Test
+  void shouldReturnEcsMetadataWhenEndpointFound() {
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    when(restTemplate.getForObject(ECS_METADATA_ENDPOINT, ContainerMetadata.class)).thenReturn(
+        new ContainerMetadata("containerArn", new LogOptions("logGroup", "region", "logStream")));
+    when(restTemplate.getForObject(ECS_METADATA_ENDPOINT + "/task", TaskMetadata.class)).thenReturn(
+        new TaskMetadata("cluster", "taskArn", "family", "revision"));
+
+    EcsMetadata ecsMetadata = configuration.ecsMetadata(restTemplate, ECS_METADATA_ENDPOINT);
+
+    assertThat("Unexpected ECS metadata.", ecsMetadata, notNullValue());
+
+    TaskMetadata taskMetadata = ecsMetadata.taskMetadata();
+    assertThat("Unexpected task metadata.", taskMetadata, notNullValue());
+    assertThat("Unexpected cluster.", taskMetadata.cluster(), is("cluster"));
+    assertThat("Unexpected task ARN.", taskMetadata.taskArn(), is("taskArn"));
+    assertThat("Unexpected family.", taskMetadata.family(), is("family"));
+
+    ContainerMetadata containerMetadata = ecsMetadata.containerMetadata();
+    assertThat("Unexpected container metadata.", containerMetadata, notNullValue());
+    assertThat("Unexpected container ARN.", containerMetadata.containerArn(), is("containerArn"));
+
+    LogOptions logOptions = containerMetadata.logOptions();
+    assertThat("Unexpected task metadata.", logOptions, notNullValue());
+    assertThat("Unexpected log group.", logOptions.logGroup(), is("logGroup"));
+    assertThat("Unexpected log region.", logOptions.region(), is("region"));
+    assertThat("Unexpected log stream.", logOptions.logStream(), is("logStream"));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenMetadataEndpointNotFound() {
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    when(restTemplate.getForObject(any(String.class), any())).thenThrow(RestClientException.class);
+
+    assertThrows(RestClientException.class,
+        () -> configuration.ecsMetadata(restTemplate, ECS_METADATA_ENDPOINT));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/config/SentryConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/config/SentryConfigurationTest.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.config;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.sentry.Sentry;
+import io.sentry.protocol.Contexts;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import uk.nhs.hee.tis.trainee.reference.config.EcsMetadataConfiguration.EcsMetadata;
+
+class SentryConfigurationTest {
+
+  @Test
+  void shouldNotAddEcsMetadataToScopeWhenNotAvailable() {
+    SentryConfiguration configuration = new SentryConfiguration(Optional.empty());
+
+    configuration.configureScope();
+
+    Sentry.withScope(scope -> {
+      Contexts contexts = scope.getContexts();
+      Object context = contexts.get("EcsMetadata");
+      assertThat("Unexpected Sentry context.", context, nullValue());
+    });
+  }
+
+  @Test
+  void shouldAddEcsMetadataToScopeWhenAvailable() {
+    EcsMetadata ecsMetadata = new EcsMetadata(null, null);
+    SentryConfiguration configuration = new SentryConfiguration(Optional.of(ecsMetadata));
+
+    configuration.configureScope();
+
+    Sentry.withScope(scope -> {
+      Contexts contexts = scope.getContexts();
+      Object context = contexts.get("EcsMetadata");
+      assertThat("Unexpected Sentry context.", context, sameInstance(ecsMetadata));
+    });
+  }
+}


### PR DESCRIPTION
The ECS metadata endpoint provides information about what and where an instance of this service is running. Including that information on X-Ray traces and Sentry error captures allows easy identification of where an issue is occuring.

Update the X-Ray and Sentry configurations to include the ECS metadata. When not running in an ECS environment (i.e. the metadata endpoint is not provided) the X-Ray and Sentry reports should not include extra metadata e.g. showing null values.

TIS21-4441
TIS21-4379