### PR TITLE
feat: get local office contacts by LO name

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.4.0"
+version = "1.5.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeContactResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeContactResource.java
@@ -34,6 +34,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.hee.tis.trainee.reference.dto.LocalOfficeContactDetailsDto;
 import uk.nhs.hee.tis.trainee.reference.dto.LocalOfficeContactDto;
 import uk.nhs.hee.tis.trainee.reference.mapper.LocalOfficeContactMapper;
 import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContact;
@@ -63,11 +64,24 @@ public class LocalOfficeContactResource {
    * @return list of LocalOfficeContacts.
    */
   @GetMapping("/local-office-contact-by-lo-uuid/{localOfficeUuid}")
-  public List<LocalOfficeContactDto> getLocalOfficeContactsByLoUuid(
+  public List<LocalOfficeContactDetailsDto> getLocalOfficeContactsByLoUuid(
       @PathVariable String localOfficeUuid) {
     log.trace("Get all LocalOfficeContacts for Local office UUID '{}'", localOfficeUuid);
     List<LocalOfficeContact> localOfficeContacts = service.getByLocalOfficeUuid(localOfficeUuid);
-    return mapper.toDtos(localOfficeContacts);
+    return mapper.toDetailsDtos(localOfficeContacts);
+  }
+
+  /**
+   * Get LocalOfficeContacts from reference table for the provided local office name.
+   *
+   * @return list of LocalOfficeContacts.
+   */
+  @GetMapping("/local-office-contact-by-lo-name/{localOfficeName}")
+  public List<LocalOfficeContactDetailsDto> getLocalOfficeContactsByLoName(
+      @PathVariable String localOfficeName) {
+    log.trace("Get all LocalOfficeContacts for Local office '{}'", localOfficeName);
+    List<LocalOfficeContact> localOfficeContacts = service.getByLocalOfficeName(localOfficeName);
+    return mapper.toDetailsDtos(localOfficeContacts);
   }
 
   /**
@@ -76,10 +90,10 @@ public class LocalOfficeContactResource {
    * @return list of LocalOfficeContacts.
    */
   @GetMapping("/local-office-contact")
-  public List<LocalOfficeContactDto> getLocalOfficeContacts() {
+  public List<LocalOfficeContactDetailsDto> getLocalOfficeContacts() {
     log.trace("Get all LocalOfficeContacts");
     List<LocalOfficeContact> localOfficeContacts = service.get();
-    return mapper.toDtos(localOfficeContacts);
+    return mapper.toDetailsDtos(localOfficeContacts);
   }
 
   /**
@@ -89,12 +103,12 @@ public class LocalOfficeContactResource {
    * @return The created (or updated) LocalOfficeContact.
    */
   @PostMapping("/local-office-contact")
-  public ResponseEntity<LocalOfficeContactDto> createLocalOfficeContact(
+  public ResponseEntity<LocalOfficeContactDetailsDto> createLocalOfficeContact(
       @RequestBody LocalOfficeContactDto localOfficeContactDto) {
     LocalOfficeContact localOfficeContact = mapper.toEntity(localOfficeContactDto);
     localOfficeContact = service.create(localOfficeContact);
     return ResponseEntity.created(URI.create("/api/localOfficeContact"))
-        .body(mapper.toDto(localOfficeContact));
+        .body(mapper.toDetailsDto(localOfficeContact));
   }
 
   /**
@@ -105,11 +119,11 @@ public class LocalOfficeContactResource {
    * @return The updated (or created) LocalOfficeContact.
    */
   @PutMapping("/local-office-contact")
-  public ResponseEntity<LocalOfficeContactDto> updateLocalOfficeContact(
+  public ResponseEntity<LocalOfficeContactDetailsDto> updateLocalOfficeContact(
       @RequestBody LocalOfficeContactDto localOfficeContactDto) {
     LocalOfficeContact localOfficeContact = mapper.toEntity(localOfficeContactDto);
     localOfficeContact = service.update(localOfficeContact);
-    return ResponseEntity.ok(mapper.toDto(localOfficeContact));
+    return ResponseEntity.ok(mapper.toDetailsDto(localOfficeContact));
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/LocalOfficeContactDetailsDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/LocalOfficeContactDetailsDto.java
@@ -19,21 +19,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.trainee.reference.repository;
+package uk.nhs.hee.tis.trainee.reference.dto;
 
-import java.util.List;
-import org.springframework.stereotype.Repository;
-import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContact;
+import lombok.Data;
 
 /**
- * Repository for local office contacts.
+ * A DTO for LocalOfficeContact entity. Holds all options for LocalOfficeContact.
  */
-@Repository
-public interface LocalOfficeContactRepository extends ReferenceRepository<LocalOfficeContact> {
+@Data
+public class LocalOfficeContactDetailsDto {
 
-  List<LocalOfficeContact> findByLocalOfficeId(String localOfficeId);
-
-  List<LocalOfficeContact> findByContactTypeId(String contactTypeId);
-
-  List<LocalOfficeContact> findByLocalOfficeName(String localOfficeName);
+  private String tisId;
+  private String localOfficeId;
+  private String contactTypeId;
+  private String contact;
+  private String label;
+  private String localOfficeName;
+  private String contactTypeName;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/facade/LocalOfficeContactEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/facade/LocalOfficeContactEnricherFacade.java
@@ -21,13 +21,12 @@
 
 package uk.nhs.hee.tis.trainee.reference.facade;
 
-import java.util.List;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.reference.model.LocalOffice;
 import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContact;
 import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContactType;
-import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeContactRepository;
 import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeContactTypeRepository;
 import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeRepository;
 
@@ -35,13 +34,11 @@ import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeRepository;
 @Component
 public class LocalOfficeContactEnricherFacade {
 
-  private LocalOfficeRepository localOfficeRepository;
-  private LocalOfficeContactTypeRepository contactTypeRepository;
-
+  private final LocalOfficeRepository localOfficeRepository;
+  private final LocalOfficeContactTypeRepository contactTypeRepository;
 
   LocalOfficeContactEnricherFacade(LocalOfficeRepository localOfficeRepository,
-      LocalOfficeContactTypeRepository contactTypeRepository,
-      LocalOfficeContactRepository contactRepository) {
+      LocalOfficeContactTypeRepository contactTypeRepository) {
     this.localOfficeRepository = localOfficeRepository;
     this.contactTypeRepository = contactTypeRepository;
   }
@@ -55,21 +52,23 @@ public class LocalOfficeContactEnricherFacade {
    * @return The enriched local office contact.
    */
   public LocalOfficeContact enrich(LocalOfficeContact localOfficeContact) {
-    LocalOffice localOffice;
-    LocalOfficeContactType contactType;
-    if (localOfficeContact.getLocalOfficeId() != null) {
-      localOffice = localOfficeRepository.findByTisId(localOfficeContact.getLocalOfficeId());
-      if (localOffice != null) {
-        localOfficeContact.setLocalOfficeName(localOffice.getLabel());
+    if (localOfficeContact != null) {
+      LocalOffice localOffice;
+      LocalOfficeContactType contactType;
+      if (localOfficeContact.getLocalOfficeId() != null) {
+        localOffice = localOfficeRepository.findByUuid(localOfficeContact.getLocalOfficeId());
+        if (localOffice != null) {
+          localOfficeContact.setLocalOfficeName(localOffice.getLabel());
+        }
       }
-    }
-    if (localOfficeContact.getContactTypeId() != null) {
-      contactType = contactTypeRepository.findByTisId(localOfficeContact.getContactTypeId());
-      if (contactType != null) {
-        localOfficeContact.setContactTypeName(contactType.getLabel());
+      if (localOfficeContact.getContactTypeId() != null) {
+        contactType = contactTypeRepository.findByTisId(localOfficeContact.getContactTypeId());
+        if (contactType != null) {
+          localOfficeContact.setContactTypeName(contactType.getLabel());
+        }
       }
+      localOfficeContact.setLabel(generateLabel(localOfficeContact));
     }
-    localOfficeContact.setLabel(generateLabel(localOfficeContact));
     return localOfficeContact;
   }
 
@@ -81,8 +80,10 @@ public class LocalOfficeContactEnricherFacade {
    */
   public LocalOfficeContact enrichWithLocalOffice(LocalOfficeContact localOfficeContact,
       String localOfficeName) {
-    localOfficeContact.setLocalOfficeName(localOfficeName);
-    localOfficeContact.setLabel(generateLabel(localOfficeContact));
+    if (localOfficeContact != null) {
+      localOfficeContact.setLocalOfficeName(localOfficeName);
+      localOfficeContact.setLabel(generateLabel(localOfficeContact));
+    }
     return localOfficeContact;
   }
 
@@ -94,8 +95,10 @@ public class LocalOfficeContactEnricherFacade {
    */
   public LocalOfficeContact enrichWithContactType(LocalOfficeContact localOfficeContact,
       String contactTypeName) {
-    localOfficeContact.setContactTypeName(contactTypeName);
-    localOfficeContact.setLabel(generateLabel(localOfficeContact));
+    if (localOfficeContact != null) {
+      localOfficeContact.setContactTypeName(contactTypeName);
+      localOfficeContact.setLabel(generateLabel(localOfficeContact));
+    }
     return localOfficeContact;
   }
 
@@ -107,9 +110,11 @@ public class LocalOfficeContactEnricherFacade {
    */
   public LocalOfficeContact enrichWithLocalOfficeAndContactType(
       LocalOfficeContact localOfficeContact, String localOfficeName, String contactTypeName) {
-    localOfficeContact.setLocalOfficeName(localOfficeName);
-    localOfficeContact.setContactTypeName(contactTypeName);
-    localOfficeContact.setLabel(generateLabel(localOfficeContact));
+    if (localOfficeContact != null) {
+      localOfficeContact.setLocalOfficeName(localOfficeName);
+      localOfficeContact.setContactTypeName(contactTypeName);
+      localOfficeContact.setLabel(generateLabel(localOfficeContact));
+    }
     return localOfficeContact;
   }
 
@@ -119,7 +124,7 @@ public class LocalOfficeContactEnricherFacade {
    * @param localOfficeContact The local office contact.
    * @return The label string.
    */
-  private String generateLabel(LocalOfficeContact localOfficeContact) {
+  protected String generateLabel(LocalOfficeContact localOfficeContact) {
     String label = localOfficeContact.getContact();
     if (localOfficeContact.getContactTypeName() != null) {
       label = label + " (" + localOfficeContact.getContactTypeName() + ")";

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/facade/LocalOfficeContactEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/facade/LocalOfficeContactEnricherFacade.java
@@ -1,0 +1,132 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.facade;
+
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.reference.model.LocalOffice;
+import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContact;
+import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContactType;
+import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeContactRepository;
+import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeContactTypeRepository;
+import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeRepository;
+
+@Slf4j
+@Component
+public class LocalOfficeContactEnricherFacade {
+
+  private LocalOfficeRepository localOfficeRepository;
+  private LocalOfficeContactTypeRepository contactTypeRepository;
+
+
+  LocalOfficeContactEnricherFacade(LocalOfficeRepository localOfficeRepository,
+      LocalOfficeContactTypeRepository contactTypeRepository,
+      LocalOfficeContactRepository contactRepository) {
+    this.localOfficeRepository = localOfficeRepository;
+    this.contactTypeRepository = contactTypeRepository;
+  }
+
+  /**
+   * Enrich a local office contact with data from the local office and the contact type. If local
+   * office or contact type do not exist (which should be at most a temporary situation) they are
+   * ignored.
+   *
+   * @param localOfficeContact The local office contact to enrich.
+   * @return The enriched local office contact.
+   */
+  public LocalOfficeContact enrich(LocalOfficeContact localOfficeContact) {
+    LocalOffice localOffice;
+    LocalOfficeContactType contactType;
+    if (localOfficeContact.getLocalOfficeId() != null) {
+      localOffice = localOfficeRepository.findByTisId(localOfficeContact.getLocalOfficeId());
+      if (localOffice != null) {
+        localOfficeContact.setLocalOfficeName(localOffice.getLabel());
+      }
+    }
+    if (localOfficeContact.getContactTypeId() != null) {
+      contactType = contactTypeRepository.findByTisId(localOfficeContact.getContactTypeId());
+      if (contactType != null) {
+        localOfficeContact.setContactTypeName(contactType.getLabel());
+      }
+    }
+    localOfficeContact.setLabel(generateLabel(localOfficeContact));
+    return localOfficeContact;
+  }
+
+  /**
+   * Enrich a local office contact with its local office name.
+   *
+   * @param localOfficeContact The local office contact to enrich.
+   * @return The enriched local office contact.
+   */
+  public LocalOfficeContact enrichWithLocalOffice(LocalOfficeContact localOfficeContact,
+      String localOfficeName) {
+    localOfficeContact.setLocalOfficeName(localOfficeName);
+    localOfficeContact.setLabel(generateLabel(localOfficeContact));
+    return localOfficeContact;
+  }
+
+  /**
+   * Enrich a local office contact with its contact type.
+   *
+   * @param localOfficeContact The local office contact to enrich.
+   * @return The enriched local office contact.
+   */
+  public LocalOfficeContact enrichWithContactType(LocalOfficeContact localOfficeContact,
+      String contactTypeName) {
+    localOfficeContact.setContactTypeName(contactTypeName);
+    localOfficeContact.setLabel(generateLabel(localOfficeContact));
+    return localOfficeContact;
+  }
+
+  /**
+   * Enrich a local office contact with its local office name and contact type name.
+   *
+   * @param localOfficeContact The local office contact to enrich.
+   * @return The enriched local office contact.
+   */
+  public LocalOfficeContact enrichWithLocalOfficeAndContactType(
+      LocalOfficeContact localOfficeContact, String localOfficeName, String contactTypeName) {
+    localOfficeContact.setLocalOfficeName(localOfficeName);
+    localOfficeContact.setContactTypeName(contactTypeName);
+    localOfficeContact.setLabel(generateLabel(localOfficeContact));
+    return localOfficeContact;
+  }
+
+  /**
+   * Generates a local office contact label string.
+   *
+   * @param localOfficeContact The local office contact.
+   * @return The label string.
+   */
+  private String generateLabel(LocalOfficeContact localOfficeContact) {
+    String label = localOfficeContact.getContact();
+    if (localOfficeContact.getContactTypeName() != null) {
+      label = label + " (" + localOfficeContact.getContactTypeName() + ")";
+    }
+    if (localOfficeContact.getLocalOfficeName() != null) {
+      label = label + " - " + localOfficeContact.getLocalOfficeName();
+    }
+    return label;
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/facade/LocalOfficeContactEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/facade/LocalOfficeContactEnricherFacade.java
@@ -21,7 +21,6 @@
 
 package uk.nhs.hee.tis.trainee.reference.facade;
 
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.reference.model.LocalOffice;
@@ -30,6 +29,9 @@ import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContactType;
 import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeContactTypeRepository;
 import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeRepository;
 
+/**
+ * A facade for enriching local office contacts with associated information.
+ */
 @Slf4j
 @Component
 public class LocalOfficeContactEnricherFacade {

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/facade/LocalOfficeContactEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/facade/LocalOfficeContactEnricherFacade.java
@@ -105,22 +105,6 @@ public class LocalOfficeContactEnricherFacade {
   }
 
   /**
-   * Enrich a local office contact with its local office name and contact type name.
-   *
-   * @param localOfficeContact The local office contact to enrich.
-   * @return The enriched local office contact.
-   */
-  public LocalOfficeContact enrichWithLocalOfficeAndContactType(
-      LocalOfficeContact localOfficeContact, String localOfficeName, String contactTypeName) {
-    if (localOfficeContact != null) {
-      localOfficeContact.setLocalOfficeName(localOfficeName);
-      localOfficeContact.setContactTypeName(contactTypeName);
-      localOfficeContact.setLabel(generateLabel(localOfficeContact));
-    }
-    return localOfficeContact;
-  }
-
-  /**
    * Generates a local office contact label string.
    *
    * @param localOfficeContact The local office contact.

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/LocalOfficeContactMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/LocalOfficeContactMapper.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
+import uk.nhs.hee.tis.trainee.reference.dto.LocalOfficeContactDetailsDto;
 import uk.nhs.hee.tis.trainee.reference.dto.LocalOfficeContactDto;
 import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContact;
 
@@ -37,6 +38,10 @@ public interface LocalOfficeContactMapper {
   LocalOfficeContactDto toDto(LocalOfficeContact localOfficeContact);
 
   List<LocalOfficeContactDto> toDtos(List<LocalOfficeContact> localOfficeContacts);
+
+  LocalOfficeContactDetailsDto toDetailsDto(LocalOfficeContact localOfficeContact);
+
+  List<LocalOfficeContactDetailsDto> toDetailsDtos(List<LocalOfficeContact> localOfficeContacts);
 
   @Mapping(target = "localOfficeName", ignore = true)
   @Mapping(target = "contactTypeName", ignore = true)

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/repository/LocalOfficeRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/repository/LocalOfficeRepository.java
@@ -24,6 +24,9 @@ package uk.nhs.hee.tis.trainee.reference.repository;
 import org.springframework.stereotype.Repository;
 import uk.nhs.hee.tis.trainee.reference.model.LocalOffice;
 
+/**
+ * A repository for local offices.
+ */
 @Repository
 public interface LocalOfficeRepository extends ReferenceRepository<LocalOffice> {
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/repository/LocalOfficeRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/repository/LocalOfficeRepository.java
@@ -27,4 +27,5 @@ import uk.nhs.hee.tis.trainee.reference.model.LocalOffice;
 @Repository
 public interface LocalOfficeRepository extends ReferenceRepository<LocalOffice> {
 
+  LocalOffice findByUuid(String uuid);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactService.java
@@ -69,6 +69,7 @@ public class LocalOfficeContactService extends AbstractReferenceService<LocalOff
   @Override
   public LocalOfficeContact create(LocalOfficeContact entity) {
     entity = facade.enrich(entity);
+    log.info("Creating local office contact '{}'", entity);
     return super.create(entity);
   }
 
@@ -81,6 +82,7 @@ public class LocalOfficeContactService extends AbstractReferenceService<LocalOff
   @Override
   public LocalOfficeContact update(LocalOfficeContact entity) {
     entity = facade.enrich(entity);
+    log.info("Updating local office contact '{}'", entity);
     return super.update(entity);
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactService.java
@@ -90,9 +90,9 @@ public class LocalOfficeContactService extends AbstractReferenceService<LocalOff
    * @param localOffice The local office that triggered the update.
    */
   public void updateAllForLocalOffice(LocalOffice localOffice) {
-    if (localOffice.getId() != null) {
+    if (localOffice.getUuid() != null) {
       List<LocalOfficeContact> localOfficeContactList = repository
-          .findByLocalOfficeId(localOffice.getId());
+          .findByLocalOfficeId(localOffice.getUuid());
       localOfficeContactList.forEach(c -> {
         log.info("Updating local office contact '{}' with local office '{}'", c.getTisId(),
             localOffice.getLabel());

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactService.java
@@ -23,9 +23,13 @@ package uk.nhs.hee.tis.trainee.reference.service;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.reference.facade.LocalOfficeContactEnricherFacade;
 import uk.nhs.hee.tis.trainee.reference.mapper.LocalOfficeContactMapper;
+import uk.nhs.hee.tis.trainee.reference.model.LocalOffice;
 import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContact;
+import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContactType;
 import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeContactRepository;
 
 /**
@@ -33,20 +37,87 @@ import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeContactRepository;
  */
 @Service
 @XRayEnabled
+@Slf4j
 public class LocalOfficeContactService extends AbstractReferenceService<LocalOfficeContact> {
 
   private LocalOfficeContactMapper mapper;
   private LocalOfficeContactRepository repository;
+  private LocalOfficeContactEnricherFacade facade;
 
   protected LocalOfficeContactService(LocalOfficeContactRepository repository,
-      LocalOfficeContactMapper mapper) {
+      LocalOfficeContactMapper mapper, LocalOfficeContactEnricherFacade facade) {
     super(repository);
     this.mapper = mapper;
     this.repository = repository;
+    this.facade = facade;
   }
 
   public List<LocalOfficeContact> getByLocalOfficeUuid(String localOfficeId) {
     return repository.findByLocalOfficeId(localOfficeId);
+  }
+
+  public List<LocalOfficeContact> getByLocalOfficeName(String localOfficeName) {
+    return repository.findByLocalOfficeName(localOfficeName);
+  }
+
+  /**
+   * Override the default create to enrich the entity before saving it.
+   *
+   * @param entity The entity to create.
+   * @return The saved entity.
+   */
+  @Override
+  public LocalOfficeContact create(LocalOfficeContact entity) {
+    entity = facade.enrich(entity);
+    return super.create(entity);
+  }
+
+  /**
+   * Override the default update to enrich the entity before saving it.
+   *
+   * @param entity The entity to update.
+   * @return The saved entity.
+   */
+  @Override
+  public LocalOfficeContact update(LocalOfficeContact entity) {
+    entity = facade.enrich(entity);
+    return super.update(entity);
+  }
+
+  /**
+   * Update all local office contacts for a given local office.
+   *
+   * @param localOffice The local office that triggered the update.
+   */
+  public void updateAllForLocalOffice(LocalOffice localOffice) {
+    if (localOffice.getId() != null) {
+      List<LocalOfficeContact> localOfficeContactList = repository
+          .findByLocalOfficeId(localOffice.getId());
+      localOfficeContactList.forEach(c -> {
+        log.info("Updating local office contact '{}' with local office '{}'", c.getTisId(),
+            localOffice.getLabel());
+        LocalOfficeContact enriched = facade.enrichWithLocalOffice(c, localOffice.getLabel());
+        super.update(enriched);
+      });
+    }
+  }
+
+  /**
+   * Update all local office contacts for a given contact type.
+   *
+   * @param contactType The contact type that triggered the update.
+   */
+  public void updateAllForContactType(LocalOfficeContactType contactType) {
+    if (contactType.getTisId() != null) {
+      List<LocalOfficeContact> localOfficeContactList = repository
+          .findByContactTypeId(contactType.getTisId());
+      localOfficeContactList.forEach(c -> {
+        log.info("Updating local office contact '{}' with contact type '{}'", c.getTisId(),
+            contactType.getLabel());
+        LocalOfficeContact enriched = facade.enrichWithContactType(c, contactType.getLabel());
+        super.update(enriched);
+      });
+    }
   }
 
   @Override

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactTypeService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactTypeService.java
@@ -36,11 +36,39 @@ public class LocalOfficeContactTypeService
     extends AbstractReferenceService<LocalOfficeContactType> {
 
   private LocalOfficeContactTypeMapper mapper;
+  private LocalOfficeContactService localOfficeContactService;
 
   protected LocalOfficeContactTypeService(LocalOfficeContactTypeRepository repository,
-      LocalOfficeContactTypeMapper mapper) {
+      LocalOfficeContactTypeMapper mapper, LocalOfficeContactService localOfficeContactService) {
     super(repository);
     this.mapper = mapper;
+    this.localOfficeContactService = localOfficeContactService;
+  }
+
+  /**
+   * Override the default create to enrich any related local office contacts after saving it.
+   *
+   * @param entity The entity to create.
+   * @return The saved entity.
+   */
+  @Override
+  public LocalOfficeContactType create(LocalOfficeContactType entity) {
+    entity = super.create(entity);
+    localOfficeContactService.updateAllForContactType(entity);
+    return entity;
+  }
+
+  /**
+   * Override the default update to enrich any related local office contacts after saving it.
+   *
+   * @param entity The entity to update.
+   * @return The saved entity.
+   */
+  @Override
+  public LocalOfficeContactType update(LocalOfficeContactType entity) {
+    entity = super.update(entity);
+    localOfficeContactService.updateAllForContactType(entity);
+    return entity;
   }
 
   @Override

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeService.java
@@ -32,10 +32,40 @@ import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeRepository;
 public class LocalOfficeService extends AbstractReferenceService<LocalOffice> {
 
   private LocalOfficeMapper mapper;
+  private LocalOfficeContactService localOfficeContactService;
 
-  protected LocalOfficeService(LocalOfficeRepository repository, LocalOfficeMapper mapper) {
+  protected LocalOfficeService(LocalOfficeRepository repository, LocalOfficeMapper mapper,
+      LocalOfficeContactService localOfficeContactService) {
     super(repository);
     this.mapper = mapper;
+    this.localOfficeContactService = localOfficeContactService;
+  }
+
+
+  /**
+   * Override the default create to enrich any related local office contacts after saving it.
+   *
+   * @param entity The entity to create.
+   * @return The saved entity.
+   */
+  @Override
+  public LocalOffice create(LocalOffice entity) {
+    entity = super.create(entity);
+    localOfficeContactService.updateAllForLocalOffice(entity);
+    return entity;
+  }
+
+  /**
+   * Override the default update to enrich any related local office contacts after saving it.
+   *
+   * @param entity The entity to update.
+   * @return The saved entity.
+   */
+  @Override
+  public LocalOffice update(LocalOffice entity) {
+    entity = super.update(entity);
+    localOfficeContactService.updateAllForLocalOffice(entity);
+    return entity;
   }
 
   @Override

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeContactResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeContactResourceTest.java
@@ -73,6 +73,8 @@ class LocalOfficeContactResourceTest {
   private static final String DEFAULT_CONTACT_1 = "https://hee.freshdesk.com/support/home";
   private static final String DEFAULT_CONTACT_2 = "england.ltft.eoe@nhs.net";
 
+  private static final String DEFAULT_LOCAL_OFFICE_NAME_1 = "Local office name";
+
   @Autowired
   private MappingJackson2HttpMessageConverter jacksonMessageConverter;
 
@@ -141,6 +143,21 @@ class LocalOfficeContactResourceTest {
         .thenReturn(contacts);
     this.mockMvc.perform(get("/api/local-office-contact-by-lo-uuid/{loUuid}",
             DEFAULT_LOCAL_OFFICE_ID_1)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").value(hasSize(1)))
+        .andExpect(jsonPath("$.[*].tisId").value(hasItem(DEFAULT_TIS_ID_1)));
+  }
+
+  @Test
+  void testGetLocalOfficeContactsByLoName() throws Exception {
+    List<LocalOfficeContact> contacts = new ArrayList<>();
+    contacts.add(contact1);
+    when(localOfficeContactServiceMock.getByLocalOfficeName(DEFAULT_LOCAL_OFFICE_NAME_1))
+        .thenReturn(contacts);
+    this.mockMvc.perform(get("/api/local-office-contact-by-lo-name/{loName}",
+            DEFAULT_LOCAL_OFFICE_NAME_1)
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/facade/LocalOfficeContactEnricherFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/facade/LocalOfficeContactEnricherFacadeTest.java
@@ -116,20 +116,6 @@ class LocalOfficeContactEnricherFacadeTest {
   }
 
   @Test
-  void enrichWithLocalOfficeAndContactTypeShouldUpdateLocalOfficeContact() {
-
-    facade.enrichWithLocalOfficeAndContactType(localOfficeContact1, "a local office name",
-        "a contact type name");
-
-    assertThat("Unexpected local office name", localOfficeContact1.getLocalOfficeName(),
-        is("a local office name"));
-    assertThat("Unexpected contact type name", localOfficeContact1.getContactTypeName(),
-        is("a contact type name"));
-    assertThat("Unexpected label", localOfficeContact1.getLabel(),
-        is(facade.generateLabel(localOfficeContact1)));
-  }
-
-  @Test
   void enrichShouldReturnNullLocalOfficeContact() {
     LocalOfficeContact enriched = facade.enrich(null);
     assertNull(enriched, "Unexpected local office contact");

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/facade/LocalOfficeContactEnricherFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/facade/LocalOfficeContactEnricherFacadeTest.java
@@ -1,10 +1,29 @@
+/*
+ * The MIT License (MIT)
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package uk.nhs.hee.tis.trainee.reference.facade;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/facade/LocalOfficeContactEnricherFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/facade/LocalOfficeContactEnricherFacadeTest.java
@@ -1,0 +1,220 @@
+package uk.nhs.hee.tis.trainee.reference.facade;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.trainee.reference.model.LocalOffice;
+import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContact;
+import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContactType;
+import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeContactTypeRepository;
+import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeRepository;
+
+@ExtendWith(MockitoExtension.class)
+class LocalOfficeContactEnricherFacadeTest {
+  private static final String DEFAULT_TIS_ID_1 = "1";
+  private static final String DEFAULT_LOCAL_OFFICE_ID_1 = UUID.randomUUID().toString();
+  private static final String DEFAULT_CONTACT_TYPE_ID_1 = UUID.randomUUID().toString();
+  private static final String DEFAULT_CONTACT_1 = "https://hee.freshdesk.com/support/home";
+  private static final String DEFAULT_LOCAL_OFFICE_1 = "Health Education England South London";
+  private static final String DEFAULT_CONTACT_TYPE_1 = "Less Than Full Time";
+
+  private LocalOfficeContact localOfficeContact1;
+
+  private LocalOfficeContactEnricherFacade facade;
+
+  @Mock
+  private LocalOfficeRepository localOfficeRepository;
+
+  @Mock
+  private LocalOfficeContactTypeRepository contactTypeRepository;
+
+  /**
+   * Set up data.
+   */
+  @BeforeEach
+  void initData() {
+    facade = new LocalOfficeContactEnricherFacade(localOfficeRepository, contactTypeRepository);
+
+    localOfficeContact1 = new LocalOfficeContact();
+    localOfficeContact1.setTisId(DEFAULT_TIS_ID_1);
+    localOfficeContact1.setLocalOfficeId(DEFAULT_LOCAL_OFFICE_ID_1);
+    localOfficeContact1.setContactTypeId(DEFAULT_CONTACT_TYPE_ID_1);
+    localOfficeContact1.setContact(DEFAULT_CONTACT_1);
+  }
+
+  @Test
+  void enrichShouldUpdateLocalOfficeContact() {
+    LocalOffice localOffice = new LocalOffice();
+    localOffice.setUuid(DEFAULT_LOCAL_OFFICE_ID_1);
+    localOffice.setLabel(DEFAULT_LOCAL_OFFICE_1);
+    when(localOfficeRepository.findByUuid(DEFAULT_LOCAL_OFFICE_ID_1)).thenReturn(localOffice);
+
+    LocalOfficeContactType contactType = new LocalOfficeContactType();
+    contactType.setTisId(DEFAULT_CONTACT_TYPE_ID_1);
+    contactType.setLabel(DEFAULT_CONTACT_TYPE_1);
+    when(contactTypeRepository.findByTisId(DEFAULT_CONTACT_TYPE_ID_1)).thenReturn(contactType);
+
+    facade.enrich(localOfficeContact1);
+
+    assertThat("Unexpected local office name", localOfficeContact1.getLocalOfficeName(),
+        is(DEFAULT_LOCAL_OFFICE_1));
+    assertThat("Unexpected contact type name", localOfficeContact1.getContactTypeName(),
+        is(DEFAULT_CONTACT_TYPE_1));
+    assertThat("Unexpected label", localOfficeContact1.getLabel(),
+        is(facade.generateLabel(localOfficeContact1)));
+  }
+
+  @Test
+  void enrichWithLocalOfficeShouldUpdateLocalOfficeContact() {
+
+    facade.enrichWithLocalOffice(localOfficeContact1, "a local office name");
+
+    assertThat("Unexpected local office name", localOfficeContact1.getLocalOfficeName(),
+        is("a local office name"));
+    assertThat("Unexpected label", localOfficeContact1.getLabel(),
+        is(facade.generateLabel(localOfficeContact1)));
+  }
+
+  @Test
+  void enrichWithContactTypeShouldUpdateLocalOfficeContact() {
+
+    facade.enrichWithContactType(localOfficeContact1, "a contact type name");
+
+    assertThat("Unexpected contact type name", localOfficeContact1.getContactTypeName(),
+        is("a contact type name"));
+    assertThat("Unexpected label", localOfficeContact1.getLabel(),
+        is(facade.generateLabel(localOfficeContact1)));
+  }
+
+  @Test
+  void enrichWithLocalOfficeAndContactTypeShouldUpdateLocalOfficeContact() {
+
+    facade.enrichWithLocalOfficeAndContactType(localOfficeContact1, "a local office name",
+        "a contact type name");
+
+    assertThat("Unexpected local office name", localOfficeContact1.getLocalOfficeName(),
+        is("a local office name"));
+    assertThat("Unexpected contact type name", localOfficeContact1.getContactTypeName(),
+        is("a contact type name"));
+    assertThat("Unexpected label", localOfficeContact1.getLabel(),
+        is(facade.generateLabel(localOfficeContact1)));
+  }
+
+  @Test
+  void enrichShouldReturnNullLocalOfficeContact() {
+    LocalOfficeContact enriched = facade.enrich(null);
+    assertNull(enriched, "Unexpected local office contact");
+  }
+
+  @Test
+  void enrichWithLocalOfficeShouldReturnNullLocalOfficeContact() {
+    LocalOfficeContact enriched = facade.enrichWithLocalOffice(null, "any name");
+    assertNull(enriched, "Unexpected local office contact");
+  }
+
+  @Test
+  void enrichWithContactTypeShouldReturnNullLocalOfficeContact() {
+    LocalOfficeContact enriched = facade.enrichWithContactType(null, "any name");
+    assertNull(enriched, "Unexpected local office contact");
+  }
+
+  @Test
+  void enrichShouldIgnoreMissingLocalOfficeRecord() {
+    when(localOfficeRepository.findByUuid(any())).thenReturn(null);
+
+    LocalOfficeContactType contactType = new LocalOfficeContactType();
+    contactType.setTisId(DEFAULT_CONTACT_TYPE_ID_1);
+    contactType.setLabel(DEFAULT_CONTACT_TYPE_1);
+    when(contactTypeRepository.findByTisId(DEFAULT_CONTACT_TYPE_ID_1)).thenReturn(contactType);
+
+    facade.enrich(localOfficeContact1);
+
+    assertNull(localOfficeContact1.getLocalOfficeName(), "Unexpected local office name");
+    assertThat("Unexpected label", localOfficeContact1.getLabel(),
+        is(facade.generateLabel(localOfficeContact1)));
+  }
+
+  @Test
+  void enrichShouldIgnoreMissingContactTypeRecord() {
+    LocalOffice localOffice = new LocalOffice();
+    localOffice.setUuid(DEFAULT_LOCAL_OFFICE_ID_1);
+    localOffice.setLabel(DEFAULT_LOCAL_OFFICE_1);
+    when(localOfficeRepository.findByUuid(DEFAULT_LOCAL_OFFICE_ID_1)).thenReturn(localOffice);
+
+    when(contactTypeRepository.findByTisId(any())).thenReturn(null);
+
+    facade.enrich(localOfficeContact1);
+
+    assertNull(localOfficeContact1.getContactTypeName(), "Unexpected contact type name");
+    assertThat("Unexpected label", localOfficeContact1.getLabel(),
+        is(facade.generateLabel(localOfficeContact1)));
+  }
+
+  @Test
+  void enrichShouldIgnoreMissingLocalOfficeId() {
+    localOfficeContact1.setLocalOfficeId(null);
+
+    LocalOfficeContactType contactType = new LocalOfficeContactType();
+    contactType.setTisId(DEFAULT_CONTACT_TYPE_ID_1);
+    contactType.setLabel(DEFAULT_CONTACT_TYPE_1);
+    when(contactTypeRepository.findByTisId(DEFAULT_CONTACT_TYPE_ID_1)).thenReturn(contactType);
+
+    facade.enrich(localOfficeContact1);
+
+    assertNull(localOfficeContact1.getLocalOfficeName(), "Unexpected local office name");
+    assertThat("Unexpected label", localOfficeContact1.getLabel(),
+        is(facade.generateLabel(localOfficeContact1)));
+  }
+
+  @Test
+  void enrichShouldIgnoreMissingContactType() {
+    localOfficeContact1.setContactTypeId(null);
+
+    LocalOffice localOffice = new LocalOffice();
+    localOffice.setUuid(DEFAULT_LOCAL_OFFICE_ID_1);
+    localOffice.setLabel(DEFAULT_LOCAL_OFFICE_1);
+    when(localOfficeRepository.findByUuid(DEFAULT_LOCAL_OFFICE_ID_1)).thenReturn(localOffice);
+
+    facade.enrich(localOfficeContact1);
+
+    assertNull(localOfficeContact1.getContactTypeName(), "Unexpected contact type name");
+    assertThat("Unexpected label", localOfficeContact1.getLabel(),
+        is(facade.generateLabel(localOfficeContact1)));
+  }
+
+  @Test
+  void generateLabelShouldCreateLabelWithAllDetails() {
+    localOfficeContact1.setLocalOfficeName(DEFAULT_LOCAL_OFFICE_1);
+    localOfficeContact1.setContactTypeName(DEFAULT_CONTACT_TYPE_1);
+    String expectedLabel = DEFAULT_CONTACT_1 + " (" + DEFAULT_CONTACT_TYPE_1 + ") - "
+        + DEFAULT_LOCAL_OFFICE_1;
+    assertThat("Unexpected label.", facade.generateLabel(localOfficeContact1),
+        is(expectedLabel));
+  }
+
+  @Test
+  void generateLabelShouldCreateLabelWithoutContactType() {
+    localOfficeContact1.setLocalOfficeName(DEFAULT_LOCAL_OFFICE_1);
+    String expectedLabel = DEFAULT_CONTACT_1 + " - " + DEFAULT_LOCAL_OFFICE_1;
+    assertThat("Unexpected label.", facade.generateLabel(localOfficeContact1),
+        is(expectedLabel));
+  }
+
+  @Test
+  void generateLabelShouldCreateLabelWithoutLocalOffice() {
+    localOfficeContact1.setContactTypeName(DEFAULT_CONTACT_TYPE_1);
+    String expectedLabel = DEFAULT_CONTACT_1 + " (" + DEFAULT_CONTACT_TYPE_1 + ")";
+    assertThat("Unexpected label.", facade.generateLabel(localOfficeContact1),
+        is(expectedLabel));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactServiceTest.java
@@ -40,6 +40,7 @@ import org.mapstruct.factory.Mappers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Sort;
+import uk.nhs.hee.tis.trainee.reference.facade.LocalOfficeContactEnricherFacade;
 import uk.nhs.hee.tis.trainee.reference.mapper.LocalOfficeContactMapper;
 import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContact;
 import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeContactRepository;
@@ -64,6 +65,9 @@ class LocalOfficeContactServiceTest {
   @Mock
   private LocalOfficeContactRepository repository;
 
+  @Mock
+  private LocalOfficeContactEnricherFacade facade;
+
   private LocalOfficeContact localOfficeContact1;
   private LocalOfficeContact localOfficeContact2;
 
@@ -73,7 +77,7 @@ class LocalOfficeContactServiceTest {
   @BeforeEach
   void initData() {
     service = new LocalOfficeContactService(repository,
-        Mappers.getMapper(LocalOfficeContactMapper.class));
+        Mappers.getMapper(LocalOfficeContactMapper.class), facade);
 
     localOfficeContact1 = new LocalOfficeContact();
     localOfficeContact1.setTisId(DEFAULT_TIS_ID_1);

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactServiceTest.java
@@ -27,6 +27,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,7 +44,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Sort;
 import uk.nhs.hee.tis.trainee.reference.facade.LocalOfficeContactEnricherFacade;
 import uk.nhs.hee.tis.trainee.reference.mapper.LocalOfficeContactMapper;
+import uk.nhs.hee.tis.trainee.reference.model.LocalOffice;
 import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContact;
+import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContactType;
 import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeContactRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -59,6 +63,15 @@ class LocalOfficeContactServiceTest {
 
   private static final String DEFAULT_CONTACT_1 = "https://hee.freshdesk.com/support/home";
   private static final String DEFAULT_CONTACT_2 = "england.ltft.eoe@nhs.net";
+
+  private static final String DEFAULT_LOCAL_OFFICE_1 = "Health Education England South London";
+  private static final String DEFAULT_LOCAL_OFFICE_2 = "Health Education England Thames Valley";
+
+  private static final String DEFAULT_CONTACT_TYPE_1 = "Less Than Full Time";
+  private static final String DEFAULT_CONTACT_TYPE_2 = "Deferral";
+
+  private static final String DEFAULT_LABEL_1 = "Label 1";
+  private static final String DEFAULT_LABEL_2 = "Label 2";
 
   private LocalOfficeContactService service;
 
@@ -84,14 +97,18 @@ class LocalOfficeContactServiceTest {
     localOfficeContact1.setLocalOfficeId(DEFAULT_LOCAL_OFFICE_ID_1);
     localOfficeContact1.setContactTypeId(DEFAULT_CONTACT_TYPE_ID_1);
     localOfficeContact1.setContact(DEFAULT_CONTACT_1);
-    localOfficeContact1.setLabel("TODO");
+    localOfficeContact1.setLocalOfficeName(DEFAULT_LOCAL_OFFICE_1);
+    localOfficeContact1.setContactTypeName(DEFAULT_CONTACT_TYPE_1);
+    localOfficeContact1.setLabel(DEFAULT_LABEL_1);
 
     localOfficeContact2 = new LocalOfficeContact();
     localOfficeContact2.setTisId(DEFAULT_TIS_ID_2);
     localOfficeContact2.setLocalOfficeId(DEFAULT_LOCAL_OFFICE_ID_2);
     localOfficeContact2.setContactTypeId(DEFAULT_CONTACT_TYPE_ID_2);
     localOfficeContact2.setContact(DEFAULT_CONTACT_2);
-    localOfficeContact2.setLabel("TODO");
+    localOfficeContact2.setLocalOfficeName(DEFAULT_LOCAL_OFFICE_2);
+    localOfficeContact2.setContactTypeName(DEFAULT_CONTACT_TYPE_2);
+    localOfficeContact2.setLabel(DEFAULT_LABEL_2);
   }
 
   @Test
@@ -100,7 +117,9 @@ class LocalOfficeContactServiceTest {
     localOfficeContacts.add(localOfficeContact1);
     localOfficeContacts.add(localOfficeContact2);
     when(repository.findAll(Sort.by("label"))).thenReturn(localOfficeContacts);
+
     List<LocalOfficeContact> allLocalOfficeContacts = service.get();
+
     assertThat("Unexpected size of returned LocalOfficeContact list",
         allLocalOfficeContacts.size(), equalTo(localOfficeContacts.size()));
     assertThat("The returned local office contact list doesn't contain the expected "
@@ -112,8 +131,25 @@ class LocalOfficeContactServiceTest {
     List<LocalOfficeContact> localOfficeContacts = new ArrayList<>();
     localOfficeContacts.add(localOfficeContact1);
     when(repository.findByLocalOfficeId(DEFAULT_LOCAL_OFFICE_ID_1)).thenReturn(localOfficeContacts);
+
     List<LocalOfficeContact> foundLocalOfficeContacts
         = service.getByLocalOfficeUuid(DEFAULT_LOCAL_OFFICE_ID_1);
+
+    assertThat("Unexpected size of returned LocalOfficeContact list",
+        foundLocalOfficeContacts.size(), equalTo(localOfficeContacts.size()));
+    assertThat("The returned local office contact list doesn't contain the expected "
+        + "local office contact", foundLocalOfficeContacts, hasItem(localOfficeContact1));
+  }
+
+  @Test
+  void getLocalOfficeContactByLocalOfficeNameShouldReturnCorrectLocalOfficeContacts() {
+    List<LocalOfficeContact> localOfficeContacts = new ArrayList<>();
+    localOfficeContacts.add(localOfficeContact1);
+    when(repository.findByLocalOfficeName(DEFAULT_LOCAL_OFFICE_1)).thenReturn(localOfficeContacts);
+
+    List<LocalOfficeContact> foundLocalOfficeContacts
+        = service.getByLocalOfficeName(DEFAULT_LOCAL_OFFICE_1);
+
     assertThat("Unexpected size of returned LocalOfficeContact list",
         foundLocalOfficeContacts.size(), equalTo(localOfficeContacts.size()));
     assertThat("The returned local office contact list doesn't contain the expected "
@@ -124,8 +160,11 @@ class LocalOfficeContactServiceTest {
   void createLocalOfficeContactShouldCreateLocalOfficeContactWhenNewTisId() {
     when(repository.findByTisId(DEFAULT_TIS_ID_2)).thenReturn(null);
     when(repository.insert(any(LocalOfficeContact.class))).thenAnswer(returnsFirstArg());
+    when(facade.enrich(localOfficeContact2)).thenReturn(localOfficeContact2);
 
     LocalOfficeContact localOfficeContact = service.create(localOfficeContact2);
+
+    verify(facade).enrich(localOfficeContact2);
 
     assertThat("Unexpected TIS id.", localOfficeContact.getTisId(), is(DEFAULT_TIS_ID_2));
     assertThat("Unexpected local office id.", localOfficeContact.getLocalOfficeId(),
@@ -134,14 +173,23 @@ class LocalOfficeContactServiceTest {
         is(DEFAULT_CONTACT_TYPE_ID_2));
     assertThat("Unexpected contact.", localOfficeContact.getContact(),
         is(DEFAULT_CONTACT_2));
+    assertThat("Unexpected local office name.", localOfficeContact.getLocalOfficeName(),
+        is(DEFAULT_LOCAL_OFFICE_2));
+    assertThat("Unexpected contact type name.", localOfficeContact.getContactTypeName(),
+        is(DEFAULT_CONTACT_TYPE_2));
+    assertThat("Unexpected label.", localOfficeContact.getLabel(),
+        is(DEFAULT_LABEL_2));
   }
 
   @Test
   void createLocalOfficeContactShouldUpdateLocalOfficeContactWhenExistingTisId() {
     when(repository.findByTisId(DEFAULT_TIS_ID_2)).thenReturn(localOfficeContact1);
     when(repository.save(any())).thenAnswer(returnsFirstArg());
+    when(facade.enrich(localOfficeContact2)).thenReturn(localOfficeContact2);
 
     LocalOfficeContact localOfficeContact = service.create(localOfficeContact2);
+
+    verify(facade, atLeastOnce()).enrich(localOfficeContact2);
 
     assertThat("Unexpected TIS id.", localOfficeContact.getTisId(), is(DEFAULT_TIS_ID_1));
     assertThat("Unexpected local office id.", localOfficeContact.getLocalOfficeId(),
@@ -150,14 +198,23 @@ class LocalOfficeContactServiceTest {
         is(DEFAULT_CONTACT_TYPE_ID_2));
     assertThat("Unexpected contact.", localOfficeContact.getContact(),
         is(DEFAULT_CONTACT_2));
+    assertThat("Unexpected local office name.", localOfficeContact.getLocalOfficeName(),
+        is(DEFAULT_LOCAL_OFFICE_2));
+    assertThat("Unexpected contact type name.", localOfficeContact.getContactTypeName(),
+        is(DEFAULT_CONTACT_TYPE_2));
+    assertThat("Unexpected label.", localOfficeContact.getLabel(),
+        is(DEFAULT_LABEL_2));
   }
 
   @Test
   void updateLocalOfficeContactShouldCreateLocalOfficeContactWhenNewTisId() {
     when(repository.findByTisId(DEFAULT_TIS_ID_2)).thenReturn(null);
     when(repository.insert(any(LocalOfficeContact.class))).thenAnswer(returnsFirstArg());
+    when(facade.enrich(localOfficeContact2)).thenReturn(localOfficeContact2);
 
     LocalOfficeContact localOfficeContact = service.update(localOfficeContact2);
+
+    verify(facade, atLeastOnce()).enrich(localOfficeContact2);
 
     assertThat("Unexpected TIS id.", localOfficeContact.getTisId(), is(DEFAULT_TIS_ID_2));
     assertThat("Unexpected local office id.", localOfficeContact.getLocalOfficeId(),
@@ -166,14 +223,23 @@ class LocalOfficeContactServiceTest {
         is(DEFAULT_CONTACT_TYPE_ID_2));
     assertThat("Unexpected contact.", localOfficeContact.getContact(),
         is(DEFAULT_CONTACT_2));
+    assertThat("Unexpected local office name.", localOfficeContact.getLocalOfficeName(),
+        is(DEFAULT_LOCAL_OFFICE_2));
+    assertThat("Unexpected contact type name.", localOfficeContact.getContactTypeName(),
+        is(DEFAULT_CONTACT_TYPE_2));
+    assertThat("Unexpected label.", localOfficeContact.getLabel(),
+        is(DEFAULT_LABEL_2));
   }
 
   @Test
   void updateLocalOfficeContactShouldUpdateLocalOfficeContactWhenExistingTisId() {
     when(repository.findByTisId(DEFAULT_TIS_ID_2)).thenReturn(localOfficeContact1);
     when(repository.save(any())).thenAnswer(returnsFirstArg());
+    when(facade.enrich(localOfficeContact2)).thenReturn(localOfficeContact2);
 
     LocalOfficeContact localOfficeContact = service.update(localOfficeContact2);
+
+    verify(facade).enrich(localOfficeContact2);
 
     assertThat("Unexpected TIS id.", localOfficeContact.getTisId(), is(DEFAULT_TIS_ID_1));
     assertThat("Unexpected local office id.", localOfficeContact.getLocalOfficeId(),
@@ -182,6 +248,12 @@ class LocalOfficeContactServiceTest {
         is(DEFAULT_CONTACT_TYPE_ID_2));
     assertThat("Unexpected contact.", localOfficeContact.getContact(),
         is(DEFAULT_CONTACT_2));
+    assertThat("Unexpected local office name.", localOfficeContact.getLocalOfficeName(),
+        is(DEFAULT_LOCAL_OFFICE_2));
+    assertThat("Unexpected contact type name.", localOfficeContact.getContactTypeName(),
+        is(DEFAULT_CONTACT_TYPE_2));
+    assertThat("Unexpected label.", localOfficeContact.getLabel(),
+        is(DEFAULT_LABEL_2));
   }
 
   @Test
@@ -189,5 +261,67 @@ class LocalOfficeContactServiceTest {
     service.deleteByTisId(DEFAULT_TIS_ID_1);
 
     verify(repository).deleteByTisId(DEFAULT_TIS_ID_1);
+  }
+
+  @Test
+  void updateAllForLocalOfficeShouldUpdateAllRelevantContacts() {
+    List<LocalOfficeContact> localOfficeContacts = new ArrayList<>();
+    localOfficeContacts.add(localOfficeContact1);
+    localOfficeContact2.setLocalOfficeId(DEFAULT_LOCAL_OFFICE_ID_1);
+    localOfficeContacts.add(localOfficeContact2);
+
+    LocalOffice localOffice = new LocalOffice();
+    localOffice.setUuid(DEFAULT_LOCAL_OFFICE_ID_1);
+    localOffice.setLabel("some local office");
+
+    when(repository.save(any())).thenAnswer(returnsFirstArg());
+    when(repository.findByLocalOfficeId(DEFAULT_LOCAL_OFFICE_ID_1)).thenReturn(localOfficeContacts);
+    when(repository.findByTisId(DEFAULT_TIS_ID_1)).thenReturn(localOfficeContact1);
+    when(repository.findByTisId(DEFAULT_TIS_ID_2)).thenReturn(localOfficeContact2);
+    when(facade.enrichWithLocalOffice(any(), any())).thenAnswer(returnsFirstArg());
+
+    service.updateAllForLocalOffice(localOffice);
+
+    verify(repository).save(localOfficeContact1);
+    verify(repository).save(localOfficeContact2);
+  }
+
+  @Test
+  void updateAllForLocalOfficeShouldUpdateNothingIfLocalOfficeEmpty() {
+
+    service.updateAllForLocalOffice(new LocalOffice());
+
+    verify(repository, never()).save(any());
+  }
+
+  @Test
+  void updateAllForContactTypeShouldUpdateAllRelevantContacts() {
+    List<LocalOfficeContact> localOfficeContacts = new ArrayList<>();
+    localOfficeContacts.add(localOfficeContact1);
+    localOfficeContact2.setContactTypeId(DEFAULT_CONTACT_TYPE_ID_1);
+    localOfficeContacts.add(localOfficeContact2);
+
+    LocalOfficeContactType contactType = new LocalOfficeContactType();
+    contactType.setTisId(DEFAULT_CONTACT_TYPE_ID_1);
+    contactType.setLabel("some label");
+
+    when(repository.save(any())).thenAnswer(returnsFirstArg());
+    when(repository.findByContactTypeId(DEFAULT_CONTACT_TYPE_ID_1)).thenReturn(localOfficeContacts);
+    when(repository.findByTisId(DEFAULT_TIS_ID_1)).thenReturn(localOfficeContact1);
+    when(repository.findByTisId(DEFAULT_TIS_ID_2)).thenReturn(localOfficeContact2);
+    when(facade.enrichWithContactType(any(), any())).thenAnswer(returnsFirstArg());
+
+    service.updateAllForContactType(contactType);
+
+    verify(repository).save(localOfficeContact1);
+    verify(repository).save(localOfficeContact2);
+  }
+
+  @Test
+  void updateAllForContactTypeShouldUpdateNothingIfContactTypeEmpty() {
+
+    service.updateAllForContactType(new LocalOfficeContactType());
+
+    verify(repository, never()).save(any());
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactTypeServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactTypeServiceTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -107,6 +108,8 @@ class LocalOfficeContactTypeServiceTest {
 
     LocalOfficeContactType contactType = service.create(contactType2);
 
+    verify(contactService).updateAllForContactType(contactType2);
+
     assertThat("Unexpected TIS id.", contactType.getTisId(), is(DEFAULT_TIS_ID_2));
     assertThat("Unexpected label.", contactType.getLabel(), is(DEFAULT_LABEL_2));
     assertThat("Unexpected code.", contactType.getCode(), is(DEFAULT_CODE_2));
@@ -118,6 +121,8 @@ class LocalOfficeContactTypeServiceTest {
     when(repository.save(any())).thenAnswer(returnsFirstArg());
 
     LocalOfficeContactType contactType = service.create(contactType2);
+
+    verify(contactService, atLeastOnce()).updateAllForContactType(contactType1);
 
     assertThat("Unexpected TIS id.", contactType.getTisId(), is(DEFAULT_TIS_ID_1));
     assertThat("Unexpected label.", contactType.getLabel(), is(DEFAULT_LABEL_2));
@@ -131,6 +136,8 @@ class LocalOfficeContactTypeServiceTest {
 
     LocalOfficeContactType contactType = service.update(contactType2);
 
+    verify(contactService, atLeastOnce()).updateAllForContactType(contactType2);
+
     assertThat("Unexpected TIS id.", contactType.getTisId(), is(DEFAULT_TIS_ID_2));
     assertThat("Unexpected label.", contactType.getLabel(), is(DEFAULT_LABEL_2));
     assertThat("Unexpected code.", contactType.getCode(), is(DEFAULT_CODE_2));
@@ -142,6 +149,8 @@ class LocalOfficeContactTypeServiceTest {
     when(repository.save(any())).thenAnswer(returnsFirstArg());
 
     LocalOfficeContactType contactType = service.update(contactType2);
+
+    verify(contactService).updateAllForContactType(contactType1);
 
     assertThat("Unexpected TIS id.", contactType.getTisId(), is(DEFAULT_TIS_ID_1));
     assertThat("Unexpected label.", contactType.getLabel(), is(DEFAULT_LABEL_2));

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactTypeServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactTypeServiceTest.java
@@ -62,6 +62,9 @@ class LocalOfficeContactTypeServiceTest {
   @Mock
   private LocalOfficeContactTypeRepository repository;
 
+  @Mock
+  private LocalOfficeContactService contactService;
+
   private LocalOfficeContactType contactType1;
   private LocalOfficeContactType contactType2;
 
@@ -71,7 +74,7 @@ class LocalOfficeContactTypeServiceTest {
   @BeforeEach
   void initData() {
     service = new LocalOfficeContactTypeService(repository,
-        Mappers.getMapper(LocalOfficeContactTypeMapper.class));
+        Mappers.getMapper(LocalOfficeContactTypeMapper.class), contactService);
 
     contactType1 = new LocalOfficeContactType();
     contactType1.setTisId(DEFAULT_TIS_ID_1);

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeServiceTest.java
@@ -27,6 +27,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -112,6 +114,8 @@ class LocalOfficeServiceTest {
 
     LocalOffice localOffice = service.create(localOffice2);
 
+    verify(contactService).updateAllForLocalOffice(localOffice2);
+
     assertThat("Unexpected id.", localOffice.getId(), is(DEFAULT_ID_2));
     assertThat("Unexpected TIS id.", localOffice.getTisId(), is(DEFAULT_TIS_ID_2));
     assertThat("Unexpected label.", localOffice.getLabel(), is(DEFAULT_LABEL_2));
@@ -124,6 +128,8 @@ class LocalOfficeServiceTest {
     when(repository.save(any())).thenAnswer(returnsFirstArg());
 
     LocalOffice localOffice = service.create(localOffice2);
+
+    verify(contactService, atLeastOnce()).updateAllForLocalOffice(localOffice1);
 
     assertThat("Unexpected id.", localOffice.getId(), is(DEFAULT_ID_1));
     assertThat("Unexpected TIS id.", localOffice.getTisId(), is(DEFAULT_TIS_ID_1));
@@ -138,6 +144,8 @@ class LocalOfficeServiceTest {
 
     LocalOffice localOffice = service.update(localOffice2);
 
+    verify(contactService, atLeastOnce()).updateAllForLocalOffice(localOffice2);
+
     assertThat("Unexpected id.", localOffice.getId(), is(DEFAULT_ID_2));
     assertThat("Unexpected TIS id.", localOffice.getTisId(), is(DEFAULT_TIS_ID_2));
     assertThat("Unexpected label.", localOffice.getLabel(), is(DEFAULT_LABEL_2));
@@ -150,6 +158,8 @@ class LocalOfficeServiceTest {
     when(repository.save(any())).thenAnswer(returnsFirstArg());
 
     LocalOffice localOffice = service.update(localOffice2);
+
+    verify(contactService).updateAllForLocalOffice(localOffice1);
 
     assertThat("Unexpected id.", localOffice.getId(), is(DEFAULT_ID_1));
     assertThat("Unexpected TIS id.", localOffice.getTisId(), is(DEFAULT_TIS_ID_1));

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeServiceTest.java
@@ -65,6 +65,9 @@ class LocalOfficeServiceTest {
   @Mock
   private LocalOfficeRepository repository;
 
+  @Mock
+  private LocalOfficeContactService contactService;
+
   private LocalOffice localOffice1;
   private LocalOffice localOffice2;
 
@@ -73,7 +76,8 @@ class LocalOfficeServiceTest {
    */
   @BeforeEach
   void initData() {
-    service = new LocalOfficeService(repository, Mappers.getMapper(LocalOfficeMapper.class));
+    service = new LocalOfficeService(repository, Mappers.getMapper(LocalOfficeMapper.class),
+        contactService);
 
     localOffice1 = new LocalOffice();
     localOffice1.setId(DEFAULT_ID_1);


### PR DESCRIPTION
Returned local office details from all endpoints are now enriched.

Dependent on https://github.com/Health-Education-England/tis-trainee-sync/pull/444

TIS21-5698