### PR TITLE
feat: only return valid PM types

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.5.0"
+version = "1.6.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/ProgrammeMembershipTypeService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/ProgrammeMembershipTypeService.java
@@ -22,6 +22,8 @@
 package uk.nhs.hee.tis.trainee.reference.service;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.reference.mapper.ProgrammeMembershipTypeMapper;
 import uk.nhs.hee.tis.trainee.reference.model.ProgrammeMembershipType;
@@ -32,12 +34,22 @@ import uk.nhs.hee.tis.trainee.reference.repository.ProgrammeMembershipTypeReposi
 public class ProgrammeMembershipTypeService
     extends AbstractReferenceService<ProgrammeMembershipType> {
 
-  private ProgrammeMembershipTypeMapper mapper;
+  private final ProgrammeMembershipTypeMapper mapper;
+  private final List<String> excludedTypes;
 
   protected ProgrammeMembershipTypeService(ProgrammeMembershipTypeRepository repository,
-      ProgrammeMembershipTypeMapper mapper) {
+      ProgrammeMembershipTypeMapper mapper,
+      @Value("${application.exclude-filters.pm-type}") List<String> excludedTypes) {
     super(repository);
     this.mapper = mapper;
+    this.excludedTypes = excludedTypes;
+  }
+
+  @Override
+  public List<ProgrammeMembershipType> get() {
+    return super.get().stream()
+        .filter(type -> !excludedTypes.contains(type.getLabel()))
+        .toList();
   }
 
   @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,7 @@
 application:
   environment: ${ENVIRONMENT:local}
+  exclude-filters:
+    pm-type: LAT,Visitor
 
 mongock:
   migration-scan-package: uk.nhs.hee.tis.trainee.reference.changelog


### PR DESCRIPTION
Several ProgrammeMembershipTypes that are `CURRENT` in TIS are no longer used, as a result they should not be selected when submitting Form Rs.

Filter the ProgrammeMembershipType values to exclude `LAT` and `Visitor` types.

TIS21-5669