### PR TITLE
test: create integration test suite

### DIFF
--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/DockerImageNames.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/DockerImageNames.java
@@ -1,0 +1,32 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference;
+
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Constants for {@link DockerImageName} values used in tests to ensure consistency.
+ */
+public class DockerImageNames {
+
+  public static final DockerImageName MONGO = DockerImageName.parse("mongo:5");
+}

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/TisTraineeReferenceApplicationIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/TisTraineeReferenceApplicationIntegrationTest.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+class TisTraineeReferenceApplicationIntegrationTest {
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Test
+  void contextLoads() {
+
+  }
+}

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/CollegeResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/CollegeResourceIntegrationTest.java
@@ -1,0 +1,180 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.reference.DockerImageNames;
+import uk.nhs.hee.tis.trainee.reference.model.College;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+class CollegeResourceIntegrationTest {
+
+  private static final String TIS_ID = "40";
+  private static final String LABEL = "Default College";
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    mongoTemplate.findAllAndRemove(new Query(), College.class);
+  }
+
+  @Test
+  void shouldGetEmptyArrayWhenNoCollegesFound() throws Exception {
+    mockMvc.perform(get("/api/college"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  void shouldGetCollegesOrderedByLabel() throws Exception {
+    College entity1 = new College();
+    entity1.setId(ObjectId.get().toString());
+    entity1.setLabel("c");
+
+    College entity2 = new College();
+    entity2.setId(ObjectId.get().toString());
+    entity2.setLabel("a");
+
+    College entity3 = new College();
+    entity3.setId(ObjectId.get().toString());
+    entity3.setLabel("b");
+
+    mongoTemplate.insertAll(List.of(entity1, entity2, entity3));
+
+    mockMvc.perform(get("/api/college"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(3))
+        .andExpect(jsonPath("$.[0].id").value(entity2.getId()))
+        .andExpect(jsonPath("$.[1].id").value(entity3.getId()))
+        .andExpect(jsonPath("$.[2].id").value(entity1.getId()));
+  }
+
+  @Test
+  void shouldCreateCollege() throws Exception {
+    String content = """
+        {
+          "tisId": "%s",
+          "label": "%s"
+        }
+        """.formatted(TIS_ID, LABEL);
+
+    mockMvc.perform(post("/api/college")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isCreated());
+
+    List<College> entities = mongoTemplate.findAll(College.class);
+    assertThat("Unexpected college count.", entities, hasSize(1));
+
+    College entity = entities.get(0);
+    assertThat("Unexpected ID.", entity.getId(), notNullValue());
+    assertThat("Unexpected TIS ID.", entity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", entity.getLabel(), is(LABEL));
+  }
+
+  @Test
+  void shouldUpdateCollege() throws Exception {
+    String id = ObjectId.get().toString();
+    College initialEntity = new College();
+    initialEntity.setId(id);
+    initialEntity.setTisId(TIS_ID);
+    initialEntity.setLabel(LABEL);
+    mongoTemplate.insert(initialEntity);
+
+    String content = """
+        {
+          "id": "%s",
+          "tisId": "%s",
+          "label": "New Label"
+        }
+        """.formatted(id, TIS_ID);
+
+    mockMvc.perform(put("/api/college")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isOk());
+
+    List<College> entities = mongoTemplate.findAll(College.class);
+    assertThat("Unexpected college count.", entities, hasSize(1));
+
+    College updatedEntity = entities.get(0);
+    assertThat("Unexpected ID.", updatedEntity.getId(), is(id));
+    assertThat("Unexpected TIS ID.", updatedEntity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", updatedEntity.getLabel(), is("New Label"));
+  }
+
+  @Test
+  void shouldDeleteCollege() throws Exception {
+    College entity = new College();
+    entity.setTisId(TIS_ID);
+    entity.setLabel(LABEL);
+    mongoTemplate.insert(entity);
+
+    mockMvc.perform(delete("/api/college/{tisId}", TIS_ID))
+        .andExpect(status().isNoContent());
+
+    long count = mongoTemplate.count(new Query(), College.class);
+    assertThat("Unexpected college count.", count, is(0L));
+  }
+}

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/CovidChangeCircumstanceResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/CovidChangeCircumstanceResourceIntegrationTest.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.reference.DockerImageNames;
+import uk.nhs.hee.tis.trainee.reference.model.CovidChangeCircumstance;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+class CovidChangeCircumstanceResourceIntegrationTest {
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    mongoTemplate.findAllAndRemove(new Query(), CovidChangeCircumstance.class);
+  }
+
+  @Test
+  void shouldGetEmptyArrayWhenNoCovidChangeCircumstancesFound() throws Exception {
+    mockMvc.perform(get("/api/covid-change-circs"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  void shouldGetCovidChangeCircumstancesOrderedByLabel() throws Exception {
+    CovidChangeCircumstance entity1 = new CovidChangeCircumstance();
+    entity1.setId(ObjectId.get().toString());
+    entity1.setLabel("c");
+
+    CovidChangeCircumstance entity2 = new CovidChangeCircumstance();
+    entity2.setId(ObjectId.get().toString());
+    entity2.setLabel("a");
+
+    CovidChangeCircumstance entity3 = new CovidChangeCircumstance();
+    entity3.setId(ObjectId.get().toString());
+    entity3.setLabel("b");
+
+    mongoTemplate.insertAll(List.of(entity1, entity2, entity3));
+
+    mockMvc.perform(get("/api/covid-change-circs"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(3))
+        .andExpect(jsonPath("$.[0].id").value(entity2.getId()))
+        .andExpect(jsonPath("$.[1].id").value(entity3.getId()))
+        .andExpect(jsonPath("$.[2].id").value(entity1.getId()));
+  }
+}

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/CurriculumResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/CurriculumResourceIntegrationTest.java
@@ -1,0 +1,188 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.reference.DockerImageNames;
+import uk.nhs.hee.tis.trainee.reference.model.Curriculum;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+class CurriculumResourceIntegrationTest {
+
+  private static final String TIS_ID = "40";
+  private static final String LABEL = "Default Curriculum";
+  private static final String SUB_TYPE = "MEDICAL_CURRICULUM";
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    mongoTemplate.findAllAndRemove(new Query(), Curriculum.class);
+  }
+
+  @Test
+  void shouldGetEmptyArrayWhenNoCurriculaFound() throws Exception {
+    mockMvc.perform(get("/api/curriculum"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  void shouldGetCurriculaOrderedByLabel() throws Exception {
+    Curriculum entity1 = new Curriculum();
+    entity1.setId(ObjectId.get().toString());
+    entity1.setLabel("c");
+
+    Curriculum entity2 = new Curriculum();
+    entity2.setId(ObjectId.get().toString());
+    entity2.setLabel("a");
+
+    Curriculum entity3 = new Curriculum();
+    entity3.setId(ObjectId.get().toString());
+    entity3.setLabel("b");
+
+    mongoTemplate.insertAll(List.of(entity1, entity2, entity3));
+
+    mockMvc.perform(get("/api/curriculum"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(3))
+        .andExpect(jsonPath("$.[0].id").value(entity2.getId()))
+        .andExpect(jsonPath("$.[1].id").value(entity3.getId()))
+        .andExpect(jsonPath("$.[2].id").value(entity1.getId()));
+  }
+
+  @Test
+  void shouldCreateCurriculum() throws Exception {
+    String content = """
+        {
+          "tisId": "%s",
+          "label": "%s",
+          "curriculumSubType": "%s",
+          "status": "CURRENT"
+        }
+        """.formatted(TIS_ID, LABEL, SUB_TYPE);
+
+    mockMvc.perform(post("/api/curriculum")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isCreated());
+
+    List<Curriculum> entities = mongoTemplate.findAll(Curriculum.class);
+    assertThat("Unexpected curriculum count.", entities, hasSize(1));
+
+    Curriculum entity = entities.get(0);
+    assertThat("Unexpected ID.", entity.getId(), notNullValue());
+    assertThat("Unexpected TIS ID.", entity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", entity.getLabel(), is(LABEL));
+    assertThat("Unexpected sub-type.", entity.getCurriculumSubType(), is(SUB_TYPE));
+  }
+
+  @Test
+  void shouldUpdateCurriculum() throws Exception {
+    String id = ObjectId.get().toString();
+    Curriculum initialEntity = new Curriculum();
+    initialEntity.setId(id);
+    initialEntity.setTisId(TIS_ID);
+    initialEntity.setLabel(LABEL);
+    initialEntity.setCurriculumSubType(SUB_TYPE);
+    mongoTemplate.insert(initialEntity);
+
+    String content = """
+        {
+          "id": "%s",
+          "tisId": "%s",
+          "label": "New Label",
+          "curriculumSubType": "SUB_SPECIALTY",
+          "status": "CURRENT"
+        }
+        """.formatted(id, TIS_ID);
+
+    mockMvc.perform(put("/api/curriculum")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isOk());
+
+    List<Curriculum> entities = mongoTemplate.findAll(Curriculum.class);
+    assertThat("Unexpected curriculum count.", entities, hasSize(1));
+
+    Curriculum updatedEntity = entities.get(0);
+    assertThat("Unexpected ID.", updatedEntity.getId(), is(id));
+    assertThat("Unexpected TIS ID.", updatedEntity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", updatedEntity.getLabel(), is("New Label"));
+    assertThat("Unexpected sub-type.", updatedEntity.getCurriculumSubType(), is("SUB_SPECIALTY"));
+  }
+
+  @Test
+  void shouldDeleteCurriculum() throws Exception {
+    Curriculum entity = new Curriculum();
+    entity.setTisId(TIS_ID);
+    entity.setLabel(LABEL);
+    mongoTemplate.insert(entity);
+
+    mockMvc.perform(delete("/api/curriculum/{tisId}", TIS_ID))
+        .andExpect(status().isNoContent());
+
+    long count = mongoTemplate.count(new Query(), Curriculum.class);
+    assertThat("Unexpected curriculum count.", count, is(0L));
+  }
+}

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/DbcResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/DbcResourceIntegrationTest.java
@@ -1,0 +1,191 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.reference.DockerImageNames;
+import uk.nhs.hee.tis.trainee.reference.model.Dbc;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+class DbcResourceIntegrationTest {
+
+  private static final String TIS_ID = "40";
+  private static final String LABEL = "Default Dbc";
+  private static final String TYPE = "Default Type";
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    mongoTemplate.findAllAndRemove(new Query(), Dbc.class);
+  }
+
+  @Test
+  void shouldGetEmptyArrayWhenNoDbcFound() throws Exception {
+    mockMvc.perform(get("/api/dbc"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  void shouldGetDbcOrderedByLabel() throws Exception {
+    Dbc entity1 = new Dbc();
+    entity1.setId(ObjectId.get().toString());
+    entity1.setLabel("c");
+
+    Dbc entity2 = new Dbc();
+    entity2.setId(ObjectId.get().toString());
+    entity2.setLabel("a");
+
+    Dbc entity3 = new Dbc();
+    entity3.setId(ObjectId.get().toString());
+    entity3.setLabel("b");
+
+    mongoTemplate.insertAll(List.of(entity1, entity2, entity3));
+
+    mockMvc.perform(get("/api/dbc"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(3))
+        .andExpect(jsonPath("$.[0].id").value(entity2.getId()))
+        .andExpect(jsonPath("$.[1].id").value(entity3.getId()))
+        .andExpect(jsonPath("$.[2].id").value(entity1.getId()));
+  }
+
+  @Test
+  void shouldCreateDbc() throws Exception {
+    String content = """
+        {
+          "tisId": "%s",
+          "label": "%s",
+          "type": "%s",
+          "internal": true
+        }
+        """.formatted(TIS_ID, LABEL, TYPE);
+
+    mockMvc.perform(post("/api/dbc")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isCreated());
+
+    List<Dbc> entities = mongoTemplate.findAll(Dbc.class);
+    assertThat("Unexpected dbc count.", entities, hasSize(1));
+
+    Dbc entity = entities.get(0);
+    assertThat("Unexpected ID.", entity.getId(), notNullValue());
+    assertThat("Unexpected TIS ID.", entity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", entity.getLabel(), is(LABEL));
+    assertThat("Unexpected type.", entity.getType(), is(TYPE));
+    assertThat("Unexpected internal flag.", entity.isInternal(), is(true));
+  }
+
+  @Test
+  void shouldUpdateDbc() throws Exception {
+    String id = ObjectId.get().toString();
+    Dbc initialEntity = new Dbc();
+    initialEntity.setId(id);
+    initialEntity.setTisId(TIS_ID);
+    initialEntity.setLabel(LABEL);
+    initialEntity.setType(TYPE);
+    initialEntity.setInternal(true);
+    mongoTemplate.insert(initialEntity);
+
+    String content = """
+        {
+          "id": "%s",
+          "tisId": "%s",
+          "label": "New Label",
+          "type": "New Type",
+          "internal": "false"
+        }
+        """.formatted(id, TIS_ID);
+
+    mockMvc.perform(put("/api/dbc")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isOk());
+
+    List<Dbc> entities = mongoTemplate.findAll(Dbc.class);
+    assertThat("Unexpected dbc count.", entities, hasSize(1));
+
+    Dbc updatedEntity = entities.get(0);
+    assertThat("Unexpected ID.", updatedEntity.getId(), is(id));
+    assertThat("Unexpected TIS ID.", updatedEntity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", updatedEntity.getLabel(), is("New Label"));
+    assertThat("Unexpected type.", updatedEntity.getType(), is("New Type"));
+    assertThat("Unexpected internal flag.", updatedEntity.isInternal(), is(false));
+  }
+
+  @Test
+  void shouldDeleteDbc() throws Exception {
+    Dbc entity = new Dbc();
+    entity.setTisId(TIS_ID);
+    entity.setLabel(LABEL);
+    mongoTemplate.insert(entity);
+
+    mockMvc.perform(delete("/api/dbc/{tisId}", TIS_ID))
+        .andExpect(status().isNoContent());
+
+    long count = mongoTemplate.count(new Query(), Dbc.class);
+    assertThat("Unexpected dbc count.", count, is(0L));
+  }
+}

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/DeclarationTypeResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/DeclarationTypeResourceIntegrationTest.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.reference.DockerImageNames;
+import uk.nhs.hee.tis.trainee.reference.model.DeclarationType;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+class DeclarationTypeResourceIntegrationTest {
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    mongoTemplate.findAllAndRemove(new Query(), DeclarationType.class);
+  }
+
+  @Test
+  void shouldGetEmptyArrayWhenNoDeclarationTypesFound() throws Exception {
+    mockMvc.perform(get("/api/declaration-type"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  void shouldGetDeclarationTypesOrderedByLabel() throws Exception {
+    DeclarationType entity1 = new DeclarationType();
+    entity1.setId(ObjectId.get().toString());
+    entity1.setLabel("c");
+
+    DeclarationType entity2 = new DeclarationType();
+    entity2.setId(ObjectId.get().toString());
+    entity2.setLabel("a");
+
+    DeclarationType entity3 = new DeclarationType();
+    entity3.setId(ObjectId.get().toString());
+    entity3.setLabel("b");
+
+    mongoTemplate.insertAll(List.of(entity1, entity2, entity3));
+
+    mockMvc.perform(get("/api/declaration-type"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(3))
+        .andExpect(jsonPath("$.[0].id").value(entity2.getId()))
+        .andExpect(jsonPath("$.[1].id").value(entity3.getId()))
+        .andExpect(jsonPath("$.[2].id").value(entity1.getId()));
+  }
+}

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/GenderResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/GenderResourceIntegrationTest.java
@@ -1,0 +1,180 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.reference.DockerImageNames;
+import uk.nhs.hee.tis.trainee.reference.model.Gender;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+class GenderResourceIntegrationTest {
+
+  private static final String TIS_ID = "40";
+  private static final String LABEL = "Default Gender";
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    mongoTemplate.findAllAndRemove(new Query(), Gender.class);
+  }
+
+  @Test
+  void shouldGetEmptyArrayWhenNoGendersFound() throws Exception {
+    mockMvc.perform(get("/api/gender"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  void shouldGetGendersOrderedByLabel() throws Exception {
+    Gender entity1 = new Gender();
+    entity1.setId(ObjectId.get().toString());
+    entity1.setLabel("c");
+
+    Gender entity2 = new Gender();
+    entity2.setId(ObjectId.get().toString());
+    entity2.setLabel("a");
+
+    Gender entity3 = new Gender();
+    entity3.setId(ObjectId.get().toString());
+    entity3.setLabel("b");
+
+    mongoTemplate.insertAll(List.of(entity1, entity2, entity3));
+
+    mockMvc.perform(get("/api/gender"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(3))
+        .andExpect(jsonPath("$.[0].id").value(entity2.getId()))
+        .andExpect(jsonPath("$.[1].id").value(entity3.getId()))
+        .andExpect(jsonPath("$.[2].id").value(entity1.getId()));
+  }
+
+  @Test
+  void shouldCreateGender() throws Exception {
+    String content = """
+        {
+          "tisId": "%s",
+          "label": "%s"
+        }
+        """.formatted(TIS_ID, LABEL);
+
+    mockMvc.perform(post("/api/gender")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isCreated());
+
+    List<Gender> entities = mongoTemplate.findAll(Gender.class);
+    assertThat("Unexpected gender count.", entities, hasSize(1));
+
+    Gender entity = entities.get(0);
+    assertThat("Unexpected ID.", entity.getId(), notNullValue());
+    assertThat("Unexpected TIS ID.", entity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", entity.getLabel(), is(LABEL));
+  }
+
+  @Test
+  void shouldUpdateGender() throws Exception {
+    String id = ObjectId.get().toString();
+    Gender initialEntity = new Gender();
+    initialEntity.setId(id);
+    initialEntity.setTisId(TIS_ID);
+    initialEntity.setLabel(LABEL);
+    mongoTemplate.insert(initialEntity);
+
+    String content = """
+        {
+          "id": "%s",
+          "tisId": "%s",
+          "label": "New Label"
+        }
+        """.formatted(id, TIS_ID);
+
+    mockMvc.perform(put("/api/gender")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isOk());
+
+    List<Gender> entities = mongoTemplate.findAll(Gender.class);
+    assertThat("Unexpected gender count.", entities, hasSize(1));
+
+    Gender updatedEntity = entities.get(0);
+    assertThat("Unexpected ID.", updatedEntity.getId(), is(id));
+    assertThat("Unexpected TIS ID.", updatedEntity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", updatedEntity.getLabel(), is("New Label"));
+  }
+
+  @Test
+  void shouldDeleteGender() throws Exception {
+    Gender entity = new Gender();
+    entity.setTisId(TIS_ID);
+    entity.setLabel(LABEL);
+    mongoTemplate.insert(entity);
+
+    mockMvc.perform(delete("/api/gender/{tisId}", TIS_ID))
+        .andExpect(status().isNoContent());
+
+    long count = mongoTemplate.count(new Query(), Gender.class);
+    assertThat("Unexpected gender count.", count, is(0L));
+  }
+}

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/GradeResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/GradeResourceIntegrationTest.java
@@ -1,0 +1,186 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.reference.DockerImageNames;
+import uk.nhs.hee.tis.trainee.reference.model.Grade;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+class GradeResourceIntegrationTest {
+
+  private static final String TIS_ID = "40";
+  private static final String LABEL = "Default Grade";
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    mongoTemplate.findAllAndRemove(new Query(), Grade.class);
+  }
+
+  @Test
+  void shouldGetEmptyArrayWhenNoGradesFound() throws Exception {
+    mockMvc.perform(get("/api/grade"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  void shouldGetGradesOrderedByLabel() throws Exception {
+    Grade entity1 = new Grade();
+    entity1.setId(ObjectId.get().toString());
+    entity1.setLabel("c");
+
+    Grade entity2 = new Grade();
+    entity2.setId(ObjectId.get().toString());
+    entity2.setLabel("a");
+
+    Grade entity3 = new Grade();
+    entity3.setId(ObjectId.get().toString());
+    entity3.setLabel("b");
+
+    mongoTemplate.insertAll(List.of(entity1, entity2, entity3));
+
+    mockMvc.perform(get("/api/grade"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(3))
+        .andExpect(jsonPath("$.[0].id").value(entity2.getId()))
+        .andExpect(jsonPath("$.[1].id").value(entity3.getId()))
+        .andExpect(jsonPath("$.[2].id").value(entity1.getId()));
+  }
+
+  @Test
+  void shouldCreateGrade() throws Exception {
+    String content = """
+        {
+          "tisId": "%s",
+          "label": "%s",
+          "placementGrade": true,
+          "trainingGrade": true,
+          "status": "CURRENT"
+        }
+        """.formatted(TIS_ID, LABEL);
+
+    mockMvc.perform(post("/api/grade")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isCreated());
+
+    List<Grade> entities = mongoTemplate.findAll(Grade.class);
+    assertThat("Unexpected grade count.", entities, hasSize(1));
+
+    Grade entity = entities.get(0);
+    assertThat("Unexpected ID.", entity.getId(), notNullValue());
+    assertThat("Unexpected TIS ID.", entity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", entity.getLabel(), is(LABEL));
+  }
+
+  @Test
+  void shouldUpdateGrade() throws Exception {
+    String id = ObjectId.get().toString();
+    Grade initialEntity = new Grade();
+    initialEntity.setId(id);
+    initialEntity.setTisId(TIS_ID);
+    initialEntity.setLabel(LABEL);
+    mongoTemplate.insert(initialEntity);
+
+    String content = """
+        {
+          "id": "%s",
+          "tisId": "%s",
+          "label": "New Label",
+          "placementGrade": true,
+          "trainingGrade": true,
+          "status": "CURRENT"
+        }
+        """.formatted(id, TIS_ID);
+
+    mockMvc.perform(put("/api/grade")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isOk());
+
+    List<Grade> entities = mongoTemplate.findAll(Grade.class);
+    assertThat("Unexpected grade count.", entities, hasSize(1));
+
+    Grade updatedEntity = entities.get(0);
+    assertThat("Unexpected ID.", updatedEntity.getId(), is(id));
+    assertThat("Unexpected TIS ID.", updatedEntity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", updatedEntity.getLabel(), is("New Label"));
+  }
+
+  @Test
+  void shouldDeleteGrade() throws Exception {
+    Grade entity = new Grade();
+    entity.setTisId(TIS_ID);
+    entity.setLabel(LABEL);
+    mongoTemplate.insert(entity);
+
+    mockMvc.perform(delete("/api/grade/{tisId}", TIS_ID))
+        .andExpect(status().isNoContent());
+
+    long count = mongoTemplate.count(new Query(), Grade.class);
+    assertThat("Unexpected grade count.", count, is(0L));
+  }
+}

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/ImmigrationStatusResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/ImmigrationStatusResourceIntegrationTest.java
@@ -1,0 +1,180 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.reference.DockerImageNames;
+import uk.nhs.hee.tis.trainee.reference.model.ImmigrationStatus;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+class ImmigrationStatusResourceIntegrationTest {
+
+  private static final String TIS_ID = "40";
+  private static final String LABEL = "Default Immigration Status";
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    mongoTemplate.findAllAndRemove(new Query(), ImmigrationStatus.class);
+  }
+
+  @Test
+  void shouldGetEmptyArrayWhenNoImmigrationStatusesFound() throws Exception {
+    mockMvc.perform(get("/api/immigration-status"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  void shouldGetImmigrationStatusesOrderedByLabel() throws Exception {
+    ImmigrationStatus entity1 = new ImmigrationStatus();
+    entity1.setId(ObjectId.get().toString());
+    entity1.setLabel("c");
+
+    ImmigrationStatus entity2 = new ImmigrationStatus();
+    entity2.setId(ObjectId.get().toString());
+    entity2.setLabel("a");
+
+    ImmigrationStatus entity3 = new ImmigrationStatus();
+    entity3.setId(ObjectId.get().toString());
+    entity3.setLabel("b");
+
+    mongoTemplate.insertAll(List.of(entity1, entity2, entity3));
+
+    mockMvc.perform(get("/api/immigration-status"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(3))
+        .andExpect(jsonPath("$.[0].id").value(entity2.getId()))
+        .andExpect(jsonPath("$.[1].id").value(entity3.getId()))
+        .andExpect(jsonPath("$.[2].id").value(entity1.getId()));
+  }
+
+  @Test
+  void shouldCreateImmigrationStatus() throws Exception {
+    String content = """
+        {
+          "tisId": "%s",
+          "label": "%s"
+        }
+        """.formatted(TIS_ID, LABEL);
+
+    mockMvc.perform(post("/api/immigration-status")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isCreated());
+
+    List<ImmigrationStatus> entities = mongoTemplate.findAll(ImmigrationStatus.class);
+    assertThat("Unexpected immigration status count.", entities, hasSize(1));
+
+    ImmigrationStatus entity = entities.get(0);
+    assertThat("Unexpected ID.", entity.getId(), notNullValue());
+    assertThat("Unexpected TIS ID.", entity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", entity.getLabel(), is(LABEL));
+  }
+
+  @Test
+  void shouldUpdateImmigrationStatus() throws Exception {
+    String id = ObjectId.get().toString();
+    ImmigrationStatus initialEntity = new ImmigrationStatus();
+    initialEntity.setId(id);
+    initialEntity.setTisId(TIS_ID);
+    initialEntity.setLabel(LABEL);
+    mongoTemplate.insert(initialEntity);
+
+    String content = """
+        {
+          "id": "%s",
+          "tisId": "%s",
+          "label": "New Label"
+        }
+        """.formatted(id, TIS_ID);
+
+    mockMvc.perform(put("/api/immigration-status")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isOk());
+
+    List<ImmigrationStatus> entities = mongoTemplate.findAll(ImmigrationStatus.class);
+    assertThat("Unexpected immigration status count.", entities, hasSize(1));
+
+    ImmigrationStatus updatedEntity = entities.get(0);
+    assertThat("Unexpected ID.", updatedEntity.getId(), is(id));
+    assertThat("Unexpected TIS ID.", updatedEntity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", updatedEntity.getLabel(), is("New Label"));
+  }
+
+  @Test
+  void shouldDeleteImmigrationStatus() throws Exception {
+    ImmigrationStatus entity = new ImmigrationStatus();
+    entity.setTisId(TIS_ID);
+    entity.setLabel(LABEL);
+    mongoTemplate.insert(entity);
+
+    mockMvc.perform(delete("/api/immigration-status/{tisId}", TIS_ID))
+        .andExpect(status().isNoContent());
+
+    long count = mongoTemplate.count(new Query(), ImmigrationStatus.class);
+    assertThat("Unexpected immigration status count.", count, is(0L));
+  }
+}

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeContactResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeContactResourceIntegrationTest.java
@@ -1,0 +1,280 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.UUID;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.reference.DockerImageNames;
+import uk.nhs.hee.tis.trainee.reference.model.LocalOffice;
+import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContact;
+import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContactType;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+class LocalOfficeContactResourceIntegrationTest {
+
+  private static final String TIS_ID = "40";
+  private static final String LABEL = "Default Local Office Contact";
+  private static final String LOCAL_OFFICE_ID = UUID.randomUUID().toString();
+  private static final String LOCAL_OFFICE_NAME = "Default Local Office Name";
+  private static final String CONTACT_TYPE_ID = UUID.randomUUID().toString();
+  private static final String CONTACT_TYPE_NAME = "Default Contact Type Name";
+  private static final String CONTACT = "Default Contact";
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    mongoTemplate.findAllAndRemove(new Query(), LocalOffice.class);
+    mongoTemplate.findAllAndRemove(new Query(), LocalOfficeContactType.class);
+    mongoTemplate.findAllAndRemove(new Query(), LocalOfficeContact.class);
+  }
+
+  @Test
+  void shouldGetEmptyArrayWhenNoLocalOfficeContactsFound() throws Exception {
+    mockMvc.perform(get("/api/local-office-contact"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  void shouldGetLocalOfficeContactsOrderedByLabel() throws Exception {
+    LocalOfficeContact entity1 = new LocalOfficeContact();
+    entity1.setTisId(ObjectId.get().toString());
+    entity1.setLabel("c");
+
+    LocalOfficeContact entity2 = new LocalOfficeContact();
+    entity2.setTisId(ObjectId.get().toString());
+    entity2.setLabel("a");
+
+    LocalOfficeContact entity3 = new LocalOfficeContact();
+    entity3.setTisId(ObjectId.get().toString());
+    entity3.setLabel("b");
+
+    mongoTemplate.insertAll(List.of(entity1, entity2, entity3));
+
+    mockMvc.perform(get("/api/local-office-contact"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(3))
+        .andExpect(jsonPath("$.[0].tisId").value(entity2.getTisId()))
+        .andExpect(jsonPath("$.[1].tisId").value(entity3.getTisId()))
+        .andExpect(jsonPath("$.[2].tisId").value(entity1.getTisId()));
+  }
+
+  @Test
+  void shouldGetLocalOfficeContactsByLocalOfficeUuid() throws Exception {
+    LocalOfficeContact entity1 = new LocalOfficeContact();
+    entity1.setTisId(TIS_ID);
+    entity1.setLocalOfficeId(LOCAL_OFFICE_ID);
+
+    LocalOfficeContact entity2 = new LocalOfficeContact();
+    entity2.setTisId(ObjectId.get().toString());
+    entity2.setLocalOfficeId(LOCAL_OFFICE_ID);
+
+    LocalOfficeContact entity3 = new LocalOfficeContact();
+    entity3.setTisId(ObjectId.get().toString());
+
+    mongoTemplate.insertAll(List.of(entity1, entity2, entity3));
+
+    mockMvc.perform(get("/api/local-office-contact-by-lo-uuid/{localOfficeUuid}", LOCAL_OFFICE_ID))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$.[0].tisId").value(entity1.getTisId()))
+        .andExpect(jsonPath("$.[1].tisId").value(entity2.getTisId()));
+  }
+
+  @Test
+  void shouldGetLocalOfficeContactsByLocalOfficeName() throws Exception {
+    LocalOfficeContact entity1 = new LocalOfficeContact();
+    entity1.setTisId(TIS_ID);
+    entity1.setLocalOfficeName(LOCAL_OFFICE_NAME);
+
+    LocalOfficeContact entity2 = new LocalOfficeContact();
+    entity2.setTisId(ObjectId.get().toString());
+    entity2.setLocalOfficeName(LOCAL_OFFICE_NAME);
+
+    LocalOfficeContact entity3 = new LocalOfficeContact();
+    entity3.setTisId(ObjectId.get().toString());
+
+    mongoTemplate.insertAll(List.of(entity1, entity2, entity3));
+
+    mockMvc.perform(
+            get("/api/local-office-contact-by-lo-name/{localOfficeName}", LOCAL_OFFICE_NAME))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$.[0].tisId").value(entity1.getTisId()))
+        .andExpect(jsonPath("$.[1].tisId").value(entity2.getTisId()));
+  }
+
+  @Test
+  void shouldCreateLocalOfficeContact() throws Exception {
+    LocalOffice localOffice = new LocalOffice();
+    localOffice.setUuid(LOCAL_OFFICE_ID);
+    localOffice.setLabel(LOCAL_OFFICE_NAME);
+    mongoTemplate.insert(localOffice);
+
+    LocalOfficeContactType contactType = new LocalOfficeContactType();
+    contactType.setTisId(CONTACT_TYPE_ID);
+    contactType.setLabel(CONTACT_TYPE_NAME);
+    mongoTemplate.insert(contactType);
+
+    String content = """
+        {
+          "tisId": "%s",
+          "label": "%s",
+          "localOfficeId": "%s",
+          "localOfficeName": "%s",
+          "contactTypeId": "%s",
+          "contactTypeName": "%s",
+          "contact": "%s"
+        }
+        """.formatted(TIS_ID, LABEL, LOCAL_OFFICE_ID, LOCAL_OFFICE_NAME, CONTACT_TYPE_ID,
+        CONTACT_TYPE_NAME, CONTACT);
+
+    mockMvc.perform(post("/api/local-office-contact")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isCreated());
+
+    List<LocalOfficeContact> entities = mongoTemplate.findAll(LocalOfficeContact.class);
+    assertThat("Unexpected local office contact count.", entities, hasSize(1));
+
+    LocalOfficeContact entity = entities.get(0);
+    assertThat("Unexpected TIS ID.", entity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", entity.getLabel(),
+        is("%s (%s) - %s".formatted(CONTACT, CONTACT_TYPE_NAME, LOCAL_OFFICE_NAME)));
+    assertThat("Unexpected local office ID.", entity.getLocalOfficeId(), is(LOCAL_OFFICE_ID));
+    assertThat("Unexpected local office name.", entity.getLocalOfficeName(), is(LOCAL_OFFICE_NAME));
+    assertThat("Unexpected contact type ID.", entity.getContactTypeId(), is(CONTACT_TYPE_ID));
+    assertThat("Unexpected contact type name.", entity.getContactTypeName(), is(CONTACT_TYPE_NAME));
+    assertThat("Unexpected contact.", entity.getContact(), is(CONTACT));
+  }
+
+  @Test
+  void shouldUpdateLocalOfficeContact() throws Exception {
+    LocalOffice localOffice = new LocalOffice();
+    localOffice.setUuid(LOCAL_OFFICE_ID);
+    localOffice.setLabel(LOCAL_OFFICE_NAME);
+    mongoTemplate.insert(localOffice);
+
+    LocalOfficeContactType contactType = new LocalOfficeContactType();
+    contactType.setTisId(CONTACT_TYPE_ID);
+    contactType.setLabel(CONTACT_TYPE_NAME);
+    mongoTemplate.insert(contactType);
+
+    LocalOfficeContact initialEntity = new LocalOfficeContact();
+    initialEntity.setTisId(TIS_ID);
+    initialEntity.setLabel(LABEL);
+    mongoTemplate.insert(initialEntity);
+
+    String content = """
+        {
+          "tisId": "%s",
+          "label": "New Label",
+          "localOfficeId": "%s",
+          "localOfficeName": "New Local Office Name",
+          "contactTypeId": "%s",
+          "contactTypeName": "New Contact Type Name",
+          "contact": "New Contact"
+        }
+        """.formatted(TIS_ID, LOCAL_OFFICE_ID, CONTACT_TYPE_ID);
+
+    mockMvc.perform(put("/api/local-office-contact")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isOk());
+
+    List<LocalOfficeContact> entities = mongoTemplate.findAll(LocalOfficeContact.class);
+    assertThat("Unexpected local office contact count.", entities, hasSize(1));
+
+    LocalOfficeContact updatedEntity = entities.get(0);
+    assertThat("Unexpected TIS ID.", updatedEntity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", updatedEntity.getLabel(),
+        is("New Contact (%s) - %s".formatted(CONTACT_TYPE_NAME, LOCAL_OFFICE_NAME)));
+    assertThat("Unexpected local office ID.", updatedEntity.getLocalOfficeId(),
+        is(LOCAL_OFFICE_ID));
+    assertThat("Unexpected local office name.", updatedEntity.getLocalOfficeName(),
+        is(LOCAL_OFFICE_NAME));
+    assertThat("Unexpected contact type ID.", updatedEntity.getContactTypeId(),
+        is(CONTACT_TYPE_ID));
+    assertThat("Unexpected contact type name.", updatedEntity.getContactTypeName(),
+        is(CONTACT_TYPE_NAME));
+    assertThat("Unexpected contact.", updatedEntity.getContact(), is("New Contact"));
+  }
+
+  @Test
+  void shouldDeleteLocalOfficeContact() throws Exception {
+    LocalOfficeContact entity = new LocalOfficeContact();
+    entity.setTisId(TIS_ID);
+    entity.setLabel(LABEL);
+    mongoTemplate.insert(entity);
+
+    mockMvc.perform(delete("/api/local-office-contact/{tisId}", TIS_ID))
+        .andExpect(status().isNoContent());
+
+    long count = mongoTemplate.count(new Query(), LocalOfficeContact.class);
+    assertThat("Unexpected local office contact count.", count, is(0L));
+  }
+}

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeContactTypeResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeContactTypeResourceIntegrationTest.java
@@ -1,0 +1,179 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.reference.DockerImageNames;
+import uk.nhs.hee.tis.trainee.reference.model.LocalOfficeContactType;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+class LocalOfficeContactTypeResourceIntegrationTest {
+
+  private static final String TIS_ID = "40";
+  private static final String LABEL = "Default Local Office Contact Type";
+  private static final String CODE = "Default Code";
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    mongoTemplate.findAllAndRemove(new Query(), LocalOfficeContactType.class);
+  }
+
+  @Test
+  void shouldGetEmptyArrayWhenNoLocalOfficeContactTypesFound() throws Exception {
+    mockMvc.perform(get("/api/local-office-contact-type"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  void shouldGetLocalOfficeContactTypesOrderedByLabel() throws Exception {
+    LocalOfficeContactType entity1 = new LocalOfficeContactType();
+    entity1.setTisId(ObjectId.get().toString());
+    entity1.setLabel("c");
+
+    LocalOfficeContactType entity2 = new LocalOfficeContactType();
+    entity2.setTisId(ObjectId.get().toString());
+    entity2.setLabel("a");
+
+    LocalOfficeContactType entity3 = new LocalOfficeContactType();
+    entity3.setTisId(ObjectId.get().toString());
+    entity3.setLabel("b");
+
+    mongoTemplate.insertAll(List.of(entity1, entity2, entity3));
+
+    mockMvc.perform(get("/api/local-office-contact-type"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(3))
+        .andExpect(jsonPath("$.[0].tisId").value(entity2.getTisId()))
+        .andExpect(jsonPath("$.[1].tisId").value(entity3.getTisId()))
+        .andExpect(jsonPath("$.[2].tisId").value(entity1.getTisId()));
+  }
+
+  @Test
+  void shouldCreateLocalOfficeContactType() throws Exception {
+    String content = """
+        {
+          "tisId": "%s",
+          "label": "%s",
+          "code": "%s"
+        }
+        """.formatted(TIS_ID, LABEL, CODE);
+
+    mockMvc.perform(post("/api/local-office-contact-type")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isCreated());
+
+    List<LocalOfficeContactType> entities = mongoTemplate.findAll(LocalOfficeContactType.class);
+    assertThat("Unexpected local office contact type count.", entities, hasSize(1));
+
+    LocalOfficeContactType entity = entities.get(0);
+    assertThat("Unexpected TIS ID.", entity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", entity.getLabel(), is(LABEL));
+    assertThat("Unexpected code.", entity.getCode(), is(CODE));
+  }
+
+  @Test
+  void shouldUpdateLocalOfficeContactType() throws Exception {
+    LocalOfficeContactType initialEntity = new LocalOfficeContactType();
+    initialEntity.setTisId(TIS_ID);
+    initialEntity.setLabel(LABEL);
+    mongoTemplate.insert(initialEntity);
+
+    String content = """
+        {
+          "tisId": "%s",
+          "label": "New Label",
+          "code": "New Code"
+        }
+        """.formatted(TIS_ID);
+
+    mockMvc.perform(put("/api/local-office-contact-type")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isOk());
+
+    List<LocalOfficeContactType> entities = mongoTemplate.findAll(LocalOfficeContactType.class);
+    assertThat("Unexpected local office contact type count.", entities, hasSize(1));
+
+    LocalOfficeContactType updatedEntity = entities.get(0);
+    assertThat("Unexpected TIS ID.", updatedEntity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", updatedEntity.getLabel(), is("New Label"));
+    assertThat("Unexpected code.", updatedEntity.getCode(), is("New Code"));
+  }
+
+  @Test
+  void shouldDeleteLocalOfficeContactType() throws Exception {
+    LocalOfficeContactType entity = new LocalOfficeContactType();
+    entity.setTisId(TIS_ID);
+    entity.setLabel(LABEL);
+    mongoTemplate.insert(entity);
+
+    mockMvc.perform(delete("/api/local-office-contact-type/{tisId}", TIS_ID))
+        .andExpect(status().isNoContent());
+
+    long count = mongoTemplate.count(new Query(), LocalOfficeContactType.class);
+    assertThat("Unexpected local office contact type count.", count, is(0L));
+  }
+}

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeResourceIntegrationTest.java
@@ -1,0 +1,186 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.UUID;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.reference.DockerImageNames;
+import uk.nhs.hee.tis.trainee.reference.model.LocalOffice;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+class LocalOfficeResourceIntegrationTest {
+
+  private static final String TIS_ID = "40";
+  private static final String LO_UUID = UUID.randomUUID().toString();
+  private static final String LABEL = "Default Local Office";
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    mongoTemplate.findAllAndRemove(new Query(), LocalOffice.class);
+  }
+
+  @Test
+  void shouldGetEmptyArrayWhenNoLocalOfficesFound() throws Exception {
+    mockMvc.perform(get("/api/local-office"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  void shouldGetLocalOfficesOrderedByLabel() throws Exception {
+    LocalOffice entity1 = new LocalOffice();
+    entity1.setId(ObjectId.get().toString());
+    entity1.setLabel("c");
+
+    LocalOffice entity2 = new LocalOffice();
+    entity2.setId(ObjectId.get().toString());
+    entity2.setLabel("a");
+
+    LocalOffice entity3 = new LocalOffice();
+    entity3.setId(ObjectId.get().toString());
+    entity3.setLabel("b");
+
+    mongoTemplate.insertAll(List.of(entity1, entity2, entity3));
+
+    mockMvc.perform(get("/api/local-office"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(3))
+        .andExpect(jsonPath("$.[0].id").value(entity2.getId()))
+        .andExpect(jsonPath("$.[1].id").value(entity3.getId()))
+        .andExpect(jsonPath("$.[2].id").value(entity1.getId()));
+  }
+
+  @Test
+  void shouldCreateLocalOffice() throws Exception {
+    String content = """
+        {
+          "tisId": "%s",
+          "label": "%s",
+          "uuid": "%s"
+        }
+        """.formatted(TIS_ID, LABEL, LO_UUID);
+
+    mockMvc.perform(post("/api/local-office")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isCreated());
+
+    List<LocalOffice> entities = mongoTemplate.findAll(LocalOffice.class);
+    assertThat("Unexpected local office count.", entities, hasSize(1));
+
+    LocalOffice entity = entities.get(0);
+    assertThat("Unexpected ID.", entity.getId(), notNullValue());
+    assertThat("Unexpected TIS ID.", entity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", entity.getLabel(), is(LABEL));
+    assertThat("Unexpected UUID.", entity.getUuid(), is(LO_UUID));
+  }
+
+  @Test
+  void shouldUpdateLocalOffice() throws Exception {
+    String id = ObjectId.get().toString();
+    LocalOffice initialEntity = new LocalOffice();
+    initialEntity.setId(id);
+    initialEntity.setTisId(TIS_ID);
+    initialEntity.setLabel(LABEL);
+    mongoTemplate.insert(initialEntity);
+
+    String content = """
+        {
+          "id": "%s",
+          "tisId": "%s",
+          "label": "New Label",
+          "uuid": "%s"
+        }
+        """.formatted(id, TIS_ID, LO_UUID);
+
+    mockMvc.perform(put("/api/local-office")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isOk());
+
+    List<LocalOffice> entities = mongoTemplate.findAll(LocalOffice.class);
+    assertThat("Unexpected local office count.", entities, hasSize(1));
+
+    LocalOffice updatedEntity = entities.get(0);
+    assertThat("Unexpected ID.", updatedEntity.getId(), is(id));
+    assertThat("Unexpected TIS ID.", updatedEntity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", updatedEntity.getLabel(), is("New Label"));
+    assertThat("Unexpected UUID.", updatedEntity.getUuid(), is(LO_UUID));
+  }
+
+  @Test
+  void shouldDeleteLocalOffice() throws Exception {
+    LocalOffice entity = new LocalOffice();
+    entity.setTisId(TIS_ID);
+    entity.setLabel(LABEL);
+    mongoTemplate.insert(entity);
+
+    mockMvc.perform(delete("/api/local-office/{tisId}", TIS_ID))
+        .andExpect(status().isNoContent());
+
+    long count = mongoTemplate.count(new Query(), LocalOffice.class);
+    assertThat("Unexpected local office count.", count, is(0L));
+  }
+}

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/ProgrammeMembershipTypeResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/api/ProgrammeMembershipTypeResourceIntegrationTest.java
@@ -1,0 +1,180 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.reference.DockerImageNames;
+import uk.nhs.hee.tis.trainee.reference.model.ProgrammeMembershipType;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+class ProgrammeMembershipTypeResourceIntegrationTest {
+
+  private static final String TIS_ID = "40";
+  private static final String LABEL = "Default ProgrammeMembershipType";
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    mongoTemplate.findAllAndRemove(new Query(), ProgrammeMembershipType.class);
+  }
+
+  @Test
+  void shouldGetEmptyArrayWhenNoProgrammeMembershipTypesFound() throws Exception {
+    mockMvc.perform(get("/api/programme-membership-type"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  void shouldGetProgrammeMembershipTypesOrderedByLabel() throws Exception {
+    ProgrammeMembershipType entity1 = new ProgrammeMembershipType();
+    entity1.setId(ObjectId.get().toString());
+    entity1.setLabel("c");
+
+    ProgrammeMembershipType entity2 = new ProgrammeMembershipType();
+    entity2.setId(ObjectId.get().toString());
+    entity2.setLabel("a");
+
+    ProgrammeMembershipType entity3 = new ProgrammeMembershipType();
+    entity3.setId(ObjectId.get().toString());
+    entity3.setLabel("b");
+
+    mongoTemplate.insertAll(List.of(entity1, entity2, entity3));
+
+    mockMvc.perform(get("/api/programme-membership-type"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(3))
+        .andExpect(jsonPath("$.[0].id").value(entity2.getId()))
+        .andExpect(jsonPath("$.[1].id").value(entity3.getId()))
+        .andExpect(jsonPath("$.[2].id").value(entity1.getId()));
+  }
+
+  @Test
+  void shouldCreateProgrammeMembershipType() throws Exception {
+    String content = """
+        {
+          "tisId": "%s",
+          "label": "%s"
+        }
+        """.formatted(TIS_ID, LABEL);
+
+    mockMvc.perform(post("/api/programme-membership-type")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isCreated());
+
+    List<ProgrammeMembershipType> entities = mongoTemplate.findAll(ProgrammeMembershipType.class);
+    assertThat("Unexpected programme membership type count.", entities, hasSize(1));
+
+    ProgrammeMembershipType entity = entities.get(0);
+    assertThat("Unexpected ID.", entity.getId(), notNullValue());
+    assertThat("Unexpected TIS ID.", entity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", entity.getLabel(), is(LABEL));
+  }
+
+  @Test
+  void shouldUpdateProgrammeMembershipType() throws Exception {
+    String id = ObjectId.get().toString();
+    ProgrammeMembershipType initialEntity = new ProgrammeMembershipType();
+    initialEntity.setId(id);
+    initialEntity.setTisId(TIS_ID);
+    initialEntity.setLabel(LABEL);
+    mongoTemplate.insert(initialEntity);
+
+    String content = """
+        {
+          "id": "%s",
+          "tisId": "%s",
+          "label": "New Label"
+        }
+        """.formatted(id, TIS_ID);
+
+    mockMvc.perform(put("/api/programme-membership-type")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+        .andExpect(status().isOk());
+
+    List<ProgrammeMembershipType> entities = mongoTemplate.findAll(ProgrammeMembershipType.class);
+    assertThat("Unexpected programme membership type count.", entities, hasSize(1));
+
+    ProgrammeMembershipType updatedEntity = entities.get(0);
+    assertThat("Unexpected ID.", updatedEntity.getId(), is(id));
+    assertThat("Unexpected TIS ID.", updatedEntity.getTisId(), is(TIS_ID));
+    assertThat("Unexpected label.", updatedEntity.getLabel(), is("New Label"));
+  }
+
+  @Test
+  void shouldDeleteProgrammeMembershipType() throws Exception {
+    ProgrammeMembershipType entity = new ProgrammeMembershipType();
+    entity.setTisId(TIS_ID);
+    entity.setLabel(LABEL);
+    mongoTemplate.insert(entity);
+
+    mockMvc.perform(delete("/api/programme-membership-type/{tisId}", TIS_ID))
+        .andExpect(status().isNoContent());
+
+    long count = mongoTemplate.count(new Query(), ProgrammeMembershipType.class);
+    assertThat("Unexpected programme membership type count.", count, is(0L));
+  }
+}

--- a/src/integrationTest/resources/application-test.yml
+++ b/src/integrationTest/resources/application-test.yml
@@ -1,0 +1,2 @@
+mongock:
+  enabled: false

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/api/CollegeResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/api/CollegeResource.java
@@ -45,8 +45,8 @@ import uk.nhs.hee.tis.trainee.reference.service.CollegeService;
 @XRayEnabled
 public class CollegeResource {
 
-  private CollegeService service;
-  private CollegeMapper mapper;
+  private final CollegeService service;
+  private final CollegeMapper mapper;
 
   public CollegeResource(CollegeService service, CollegeMapper mapper) {
     this.service = service;
@@ -59,7 +59,7 @@ public class CollegeResource {
    * @return list of Colleges.
    */
   @GetMapping("/college")
-  public List<CollegeDto> getCollege() {
+  public List<CollegeDto> getColleges() {
     log.trace("Get all College");
     List<College> colleges = service.get();
     return mapper.toDtos(colleges);

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/api/DbcResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/api/DbcResource.java
@@ -59,7 +59,7 @@ public class DbcResource {
    * @return list of Dbcs.
    */
   @GetMapping
-  public List<DbcDto> getDbc() {
+  public List<DbcDto> getDbcs() {
     log.trace("Get all Dbcs");
     List<Dbc> dbcs = service.get();
     return mapper.toDtos(dbcs);

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/api/DeclarationTypeResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/api/DeclarationTypeResource.java
@@ -39,8 +39,8 @@ public class DeclarationTypeResource {
 
   private static final Logger log = LoggerFactory.getLogger(DeclarationTypeResource.class);
 
-  private DeclarationTypeService declarationTypeService;
-  private DeclarationTypeMapper declarationTypeMapper;
+  private final DeclarationTypeService declarationTypeService;
+  private final DeclarationTypeMapper declarationTypeMapper;
 
   public DeclarationTypeResource(DeclarationTypeService declarationTypeService,
       DeclarationTypeMapper declarationTypeMapper) {
@@ -54,7 +54,7 @@ public class DeclarationTypeResource {
    * @return list of DeclarationTypes.
    */
   @GetMapping("/declaration-type")
-  public List<DeclarationTypeDto> getDeclarationType() {
+  public List<DeclarationTypeDto> getDeclarationTypes() {
     log.trace("Get all DeclarationType");
     List<DeclarationType> declarationTypes = declarationTypeService.getDeclarationType();
     return declarationTypeMapper.toDtos(declarationTypes);

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/api/GenderResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/api/GenderResource.java
@@ -47,8 +47,8 @@ public class GenderResource {
 
   private static final Logger log = LoggerFactory.getLogger(GenderResource.class);
 
-  private GenderService service;
-  private GenderMapper mapper;
+  private final GenderService service;
+  private final GenderMapper mapper;
 
   public GenderResource(GenderService service, GenderMapper mapper) {
     this.service = service;
@@ -61,7 +61,7 @@ public class GenderResource {
    * @return list of Genders.
    */
   @GetMapping("/gender")
-  public List<GenderDto> getGender() {
+  public List<GenderDto> getGenders() {
     log.trace("Get all Genders");
     List<Gender> genders = service.get();
     return mapper.toDtos(genders);

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/api/ImmigrationStatusResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/api/ImmigrationStatusResource.java
@@ -44,8 +44,8 @@ import uk.nhs.hee.tis.trainee.reference.service.ImmigrationStatusService;
 @XRayEnabled
 public class ImmigrationStatusResource {
 
-  private ImmigrationStatusService service;
-  private ImmigrationStatusMapper mapper;
+  private final ImmigrationStatusService service;
+  private final ImmigrationStatusMapper mapper;
 
   public ImmigrationStatusResource(ImmigrationStatusService service,
       ImmigrationStatusMapper mapper) {
@@ -59,7 +59,7 @@ public class ImmigrationStatusResource {
    * @return list of ImmigrationStatus.
    */
   @GetMapping("/immigration-status")
-  public List<ImmigrationStatusDto> getImmigrationStatus() {
+  public List<ImmigrationStatusDto> getImmigrationStatuses() {
     log.trace("Get all ImmigrationStatus");
     List<ImmigrationStatus> immigrationStatus = service.get();
     return mapper.toDtos(immigrationStatus);
@@ -76,7 +76,7 @@ public class ImmigrationStatusResource {
       @RequestBody ImmigrationStatusDto immigrationStatusDto) {
     ImmigrationStatus immigrationStatus = mapper.toEntity(immigrationStatusDto);
     immigrationStatus = service.create(immigrationStatus);
-    return ResponseEntity.created(URI.create("/api/immigrationStatus"))
+    return ResponseEntity.created(URI.create("/api/immigration-status"))
         .body(mapper.toDto(immigrationStatus));
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeContactResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeContactResource.java
@@ -49,8 +49,8 @@ import uk.nhs.hee.tis.trainee.reference.service.LocalOfficeContactService;
 @XRayEnabled
 public class LocalOfficeContactResource {
 
-  private LocalOfficeContactService service;
-  private LocalOfficeContactMapper mapper;
+  private final LocalOfficeContactService service;
+  private final LocalOfficeContactMapper mapper;
 
   public LocalOfficeContactResource(LocalOfficeContactService service,
       LocalOfficeContactMapper mapper) {
@@ -107,7 +107,7 @@ public class LocalOfficeContactResource {
       @RequestBody LocalOfficeContactDto localOfficeContactDto) {
     LocalOfficeContact localOfficeContact = mapper.toEntity(localOfficeContactDto);
     localOfficeContact = service.create(localOfficeContact);
-    return ResponseEntity.created(URI.create("/api/localOfficeContact"))
+    return ResponseEntity.created(URI.create("/api/local-office-contact"))
         .body(mapper.toDetailsDto(localOfficeContact));
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeContactTypeResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeContactTypeResource.java
@@ -48,8 +48,8 @@ import uk.nhs.hee.tis.trainee.reference.service.LocalOfficeContactTypeService;
 @XRayEnabled
 public class LocalOfficeContactTypeResource {
 
-  private LocalOfficeContactTypeService service;
-  private LocalOfficeContactTypeMapper mapper;
+  private final LocalOfficeContactTypeService service;
+  private final LocalOfficeContactTypeMapper mapper;
 
   public LocalOfficeContactTypeResource(LocalOfficeContactTypeService service,
       LocalOfficeContactTypeMapper mapper) {
@@ -63,7 +63,7 @@ public class LocalOfficeContactTypeResource {
    * @return list of LocalOfficeContactTypes.
    */
   @GetMapping("/local-office-contact-type")
-  public List<LocalOfficeContactTypeDto> getLocalOfficeContactType() {
+  public List<LocalOfficeContactTypeDto> getLocalOfficeContactTypes() {
     log.trace("Get all LocalOfficeContactTypes");
     List<LocalOfficeContactType> localOfficeContactTypes = service.get();
     return mapper.toDtos(localOfficeContactTypes);
@@ -81,7 +81,7 @@ public class LocalOfficeContactTypeResource {
       @RequestBody LocalOfficeContactTypeDto localOfficeContactTypeDto) {
     LocalOfficeContactType localOfficeContactType = mapper.toEntity(localOfficeContactTypeDto);
     localOfficeContactType = service.create(localOfficeContactType);
-    return ResponseEntity.created(URI.create("/api/localOfficeContactType"))
+    return ResponseEntity.created(URI.create("/api/local-office-contact-type"))
         .body(mapper.toDto(localOfficeContactType));
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeResource.java
@@ -45,8 +45,8 @@ import uk.nhs.hee.tis.trainee.reference.service.LocalOfficeService;
 @XRayEnabled
 public class LocalOfficeResource {
 
-  private LocalOfficeService service;
-  private LocalOfficeMapper mapper;
+  private final LocalOfficeService service;
+  private final LocalOfficeMapper mapper;
 
   public LocalOfficeResource(LocalOfficeService service, LocalOfficeMapper mapper) {
     this.service = service;
@@ -59,7 +59,7 @@ public class LocalOfficeResource {
    * @return list of LocalOffices.
    */
   @GetMapping("/local-office")
-  public List<LocalOfficeDto> getLocalOffice() {
+  public List<LocalOfficeDto> getLocalOffices() {
     log.trace("Get all LocalOffices");
     List<LocalOffice> localOffices = service.get();
     return mapper.toDtos(localOffices);
@@ -72,11 +72,11 @@ public class LocalOfficeResource {
    * @return The created (or updated) LocalOffice.
    */
   @PostMapping("/local-office")
-  public ResponseEntity<LocalOfficeDto> createLocalOffice(
+  public ResponseEntity<LocalOfficeDto> createLocalOffices(
       @RequestBody LocalOfficeDto localOfficeDto) {
     LocalOffice localOffice = mapper.toEntity(localOfficeDto);
     localOffice = service.create(localOffice);
-    return ResponseEntity.created(URI.create("/api/localOffice")).body(mapper.toDto(localOffice));
+    return ResponseEntity.created(URI.create("/api/local-office")).body(mapper.toDto(localOffice));
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/CollegeResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/CollegeResourceTest.java
@@ -21,42 +21,29 @@
 
 package uk.nhs.hee.tis.trainee.reference.api;
 
-import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.OK;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.ArrayList;
+import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mapstruct.factory.Mappers;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import uk.nhs.hee.tis.trainee.reference.mapper.CollegeMapper;
+import org.springframework.http.ResponseEntity;
+import uk.nhs.hee.tis.trainee.reference.dto.CollegeDto;
+import uk.nhs.hee.tis.trainee.reference.mapper.CollegeMapperImpl;
 import uk.nhs.hee.tis.trainee.reference.model.College;
 import uk.nhs.hee.tis.trainee.reference.service.CollegeService;
 
-@ContextConfiguration(classes = {CollegeMapper.class})
-@ExtendWith(SpringExtension.class)
-@WebMvcTest(CollegeResource.class)
 class CollegeResourceTest {
 
   private static final String DEFAULT_ID_1 = "DEFAULT_ID_1";
@@ -68,99 +55,97 @@ class CollegeResourceTest {
   private static final String DEFAULT_LABEL_1 = "Faculty Of Dental Surgery";
   private static final String DEFAULT_LABEL_2 = "Faculty of Intensive Care Medicine";
 
+  private CollegeResource controller;
+  private CollegeService service;
 
-  @Autowired
-  private MappingJackson2HttpMessageConverter jacksonMessageConverter;
-
-  @Autowired
-  private ObjectMapper mapper;
-
-  private MockMvc mockMvc;
-
-  @MockBean
-  private CollegeService collegeServiceMock;
-
-  private College college1;
-  private College college2;
-
-  /**
-   * Set up mocks before each test.
-   */
   @BeforeEach
   void setup() {
-    CollegeMapper mapper = Mappers.getMapper(CollegeMapper.class);
-    CollegeResource collegeResource = new CollegeResource(collegeServiceMock, mapper);
-    mockMvc = MockMvcBuilders.standaloneSetup(collegeResource)
-        .setMessageConverters(jacksonMessageConverter)
-        .build();
-  }
-
-  /**
-   * Set up data.
-   */
-  @BeforeEach
-  void initData() {
-    college1 = new College();
-    college1.setId(DEFAULT_ID_1);
-    college1.setTisId(DEFAULT_TIS_ID_1);
-    college1.setLabel(DEFAULT_LABEL_1);
-
-    college2 = new College();
-    college2.setId(DEFAULT_ID_2);
-    college2.setTisId(DEFAULT_TIS_ID_2);
-    college2.setLabel(DEFAULT_LABEL_2);
+    service = mock(CollegeService.class);
+    controller = new CollegeResource(service, new CollegeMapperImpl());
   }
 
   @Test
-  void testGetAllColleges() throws Exception {
-    List<College> colleges = new ArrayList<>();
-    colleges.add(college1);
-    colleges.add(college2);
-    when(collegeServiceMock.get()).thenReturn(colleges);
-    this.mockMvc.perform(get("/api/college")
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$").value(hasSize(2)))
-        .andExpect(jsonPath("$.[*].id").value(hasItem(DEFAULT_ID_1)))
-        .andExpect(jsonPath("$.[*].id").value(hasItem(DEFAULT_ID_2)));
+  void shouldGetAllColleges() {
+    College entity1 = new College();
+    entity1.setId(DEFAULT_ID_1);
+    entity1.setTisId(DEFAULT_TIS_ID_1);
+    entity1.setLabel(DEFAULT_LABEL_1);
+
+    College entity2 = new College();
+    entity2.setId(DEFAULT_ID_2);
+    entity2.setTisId(DEFAULT_TIS_ID_2);
+    entity2.setLabel(DEFAULT_LABEL_2);
+
+    when(service.get()).thenReturn(List.of(entity1, entity2));
+
+    List<CollegeDto> dtos = controller.getColleges();
+
+    assertThat("Unexpected response count.", dtos, hasSize(2));
+
+    CollegeDto dto1 = dtos.get(0);
+    assertThat("Unexpected ID.", dto1.getId(), is(DEFAULT_ID_1));
+    assertThat("Unexpected TIS ID.", dto1.getTisId(), is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected label.", dto1.getLabel(), is(DEFAULT_LABEL_1));
+
+    CollegeDto dto2 = dtos.get(1);
+    assertThat("Unexpected ID.", dto2.getId(), is(DEFAULT_ID_2));
+    assertThat("Unexpected TIS ID.", dto2.getTisId(), is(DEFAULT_TIS_ID_2));
+    assertThat("Unexpected label.", dto2.getLabel(), is(DEFAULT_LABEL_2));
   }
 
   @Test
-  void testCreateCollege() throws Exception {
-    when(collegeServiceMock.create(college1)).thenReturn(college1);
+  void shouldCreateCollege() {
+    CollegeDto dto = new CollegeDto();
+    dto.setTisId(DEFAULT_TIS_ID_1);
+    dto.setLabel(DEFAULT_LABEL_1);
 
-    mockMvc.perform(post("/api/college")
-        .content(mapper.writeValueAsBytes(college1))
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isCreated())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.id").value(is(DEFAULT_ID_1)))
-        .andExpect(jsonPath("$.tisId").value(is(DEFAULT_TIS_ID_1)))
-        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_1)));
+    when(service.create(any())).thenAnswer(inv -> {
+      College entity = inv.getArgument(0);
+      assertThat("Unexpected ID.", entity.getId(), nullValue());
+      entity.setId(DEFAULT_ID_1);
+      return entity;
+    });
+
+    ResponseEntity<CollegeDto> response = controller.createCollege(dto);
+
+    assertThat("Unexpected status code.", response.getStatusCode(), is(CREATED));
+    assertThat("Unexpected location.", response.getHeaders().getLocation(),
+        is(URI.create("/api/college")));
+
+    CollegeDto body = response.getBody();
+    assertThat("Unexpected body.", body, notNullValue());
+    assertThat("Unexpected ID.", body.getId(), is(DEFAULT_ID_1));
+    assertThat("Unexpected TIS ID.", body.getTisId(), is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected label.", body.getLabel(), is(DEFAULT_LABEL_1));
   }
 
   @Test
-  void testUpdateCollege() throws Exception {
-    when(collegeServiceMock.update(college1)).thenReturn(college1);
+  void shouldUpdateCollege() {
+    CollegeDto dto = new CollegeDto();
+    dto.setId(DEFAULT_ID_1);
+    dto.setTisId(DEFAULT_TIS_ID_1);
+    dto.setLabel(DEFAULT_LABEL_1);
 
-    mockMvc.perform(put("/api/college")
-        .content(mapper.writeValueAsBytes(college1))
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.id").value(is(DEFAULT_ID_1)))
-        .andExpect(jsonPath("$.tisId").value(is(DEFAULT_TIS_ID_1)))
-        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_1)));
+    when(service.update(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    ResponseEntity<CollegeDto> response = controller.updateCollege(dto);
+
+    assertThat("Unexpected status code.", response.getStatusCode(), is(OK));
+
+    CollegeDto body = response.getBody();
+    assertThat("Unexpected body.", body, notNullValue());
+    assertThat("Unexpected ID.", body.getId(), is(DEFAULT_ID_1));
+    assertThat("Unexpected TIS ID.", body.getTisId(), is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected label.", body.getLabel(), is(DEFAULT_LABEL_1));
   }
 
   @Test
-  void testDeleteCollege() throws Exception {
-    mockMvc.perform(delete("/api/college/{tisId}", DEFAULT_TIS_ID_1)
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isNoContent())
-        .andExpect(jsonPath("$").doesNotExist());
+  void shouldDeleteCollege() {
+    ResponseEntity<Void> response = controller.deleteCollege(DEFAULT_TIS_ID_1);
 
-    verify(collegeServiceMock).deleteByTisId(DEFAULT_TIS_ID_1);
+    assertThat("Unexpected status code.", response.getStatusCode(), is(NO_CONTENT));
+    assertThat("Unexpected response body presence.", response.hasBody(), is(false));
+
+    verify(service).deleteByTisId(DEFAULT_TIS_ID_1);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/CovidChangeCircumstanceResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/CovidChangeCircumstanceResourceTest.java
@@ -21,34 +21,20 @@
 
 package uk.nhs.hee.tis.trainee.reference.api;
 
-import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.nhs.hee.tis.trainee.reference.dto.CovidChangeCircumstanceDto;
-import uk.nhs.hee.tis.trainee.reference.mapper.CovidChangeCircumstanceMapper;
+import uk.nhs.hee.tis.trainee.reference.mapper.CovidChangeCircumstanceMapperImpl;
 import uk.nhs.hee.tis.trainee.reference.model.CovidChangeCircumstance;
 import uk.nhs.hee.tis.trainee.reference.service.CovidChangeCircumstanceService;
 
-@ExtendWith(SpringExtension.class)
-@WebMvcTest(controllers = CovidChangeCircumstanceResource.class)
 class CovidChangeCircumstanceResourceTest {
 
   private static final String DEFAULT_ID_1 = "DEFAULT_ID_1";
@@ -57,72 +43,38 @@ class CovidChangeCircumstanceResourceTest {
   private static final String DEFAULT_LABEL_1 = "DEFAULT_LABEL_1";
   private static final String DEFAULT_LABEL_2 = "DEFAULT_LABEL_2";
 
-  @Autowired
-  private MappingJackson2HttpMessageConverter jacksonMessageConverter;
+  private CovidChangeCircumstanceResource controller;
+  private CovidChangeCircumstanceService service;
 
-  private MockMvc mockMvc;
-
-  @MockBean
-  private CovidChangeCircumstanceService covidChangeCircServiceMock;
-
-  @MockBean
-  private CovidChangeCircumstanceMapper covidChangeCircMapperMock;
-
-  private CovidChangeCircumstance covidChangeCirc1;
-  private CovidChangeCircumstance covidChangeCirc2;
-  private CovidChangeCircumstanceDto covidChangeCircDto1;
-  private CovidChangeCircumstanceDto covidChangeCircDto2;
-
-  /**
-   * Set up mocks before each test.
-   */
   @BeforeEach
   public void setup() {
-    CovidChangeCircumstanceResource collegeChangeCircResource = new CovidChangeCircumstanceResource(
-        covidChangeCircServiceMock, covidChangeCircMapperMock);
-    mockMvc = MockMvcBuilders.standaloneSetup(collegeChangeCircResource)
-        .setMessageConverters(jacksonMessageConverter)
-        .build();
-  }
-
-  /**
-   * Set up data.
-   */
-  @BeforeEach
-  public void initData() {
-    covidChangeCirc1 = new CovidChangeCircumstance();
-    covidChangeCirc1.setId(DEFAULT_ID_1);
-    covidChangeCirc1.setLabel(DEFAULT_LABEL_1);
-
-    covidChangeCirc2 = new CovidChangeCircumstance();
-    covidChangeCirc2.setId(DEFAULT_ID_2);
-    covidChangeCirc2.setLabel(DEFAULT_LABEL_2);
-
-    covidChangeCircDto1 = new CovidChangeCircumstanceDto();
-    covidChangeCircDto1.setId(DEFAULT_ID_1);
-    covidChangeCircDto1.setLabel(DEFAULT_LABEL_1);
-
-    covidChangeCircDto2 = new CovidChangeCircumstanceDto();
-    covidChangeCircDto2.setId(DEFAULT_ID_2);
-    covidChangeCircDto2.setLabel(DEFAULT_LABEL_2);
+    service = mock(CovidChangeCircumstanceService.class);
+    controller = new CovidChangeCircumstanceResource(service,
+        new CovidChangeCircumstanceMapperImpl());
   }
 
   @Test
-  void testGetAllCovidChangeCircs() throws Exception {
-    List<CovidChangeCircumstance> covidChangeCircs = new ArrayList<>();
-    covidChangeCircs.add(covidChangeCirc1);
-    covidChangeCircs.add(covidChangeCirc2);
-    List<CovidChangeCircumstanceDto> covidChangeCircsDtos = new ArrayList<>();
-    covidChangeCircsDtos.add(covidChangeCircDto1);
-    covidChangeCircsDtos.add(covidChangeCircDto2);
-    when(covidChangeCircServiceMock.getCovidChangeCircumstances()).thenReturn(covidChangeCircs);
-    when(covidChangeCircMapperMock.toDtos(covidChangeCircs)).thenReturn(covidChangeCircsDtos);
-    this.mockMvc.perform(get("/api/covid-change-circs")
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$").value(hasSize(covidChangeCircsDtos.size())))
-        .andExpect(jsonPath("$.[*].id").value(hasItem(DEFAULT_ID_1)))
-        .andExpect(jsonPath("$.[*].id").value(hasItem(DEFAULT_ID_2)));
+  void shouldGetAllCovidChangeCircumstances() {
+    CovidChangeCircumstance entity1 = new CovidChangeCircumstance();
+    entity1.setId(DEFAULT_ID_1);
+    entity1.setLabel(DEFAULT_LABEL_1);
+
+    CovidChangeCircumstance entity2 = new CovidChangeCircumstance();
+    entity2.setId(DEFAULT_ID_2);
+    entity2.setLabel(DEFAULT_LABEL_2);
+
+    when(service.getCovidChangeCircumstances()).thenReturn(List.of(entity1, entity2));
+
+    List<CovidChangeCircumstanceDto> dtos = controller.getCovidChangeCircumstance();
+
+    assertThat("Unexpected response count.", dtos, hasSize(2));
+
+    CovidChangeCircumstanceDto dto1 = dtos.get(0);
+    assertThat("Unexpected ID.", dto1.getId(), is(DEFAULT_ID_1));
+    assertThat("Unexpected label.", dto1.getLabel(), is(DEFAULT_LABEL_1));
+
+    CovidChangeCircumstanceDto dto2 = dtos.get(1);
+    assertThat("Unexpected ID.", dto2.getId(), is(DEFAULT_ID_2));
+    assertThat("Unexpected label.", dto2.getLabel(), is(DEFAULT_LABEL_2));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/DeclarationTypeResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/DeclarationTypeResourceTest.java
@@ -20,34 +20,20 @@
 
 package uk.nhs.hee.tis.trainee.reference.api;
 
-import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.nhs.hee.tis.trainee.reference.dto.DeclarationTypeDto;
-import uk.nhs.hee.tis.trainee.reference.mapper.DeclarationTypeMapper;
+import uk.nhs.hee.tis.trainee.reference.mapper.DeclarationTypeMapperImpl;
 import uk.nhs.hee.tis.trainee.reference.model.DeclarationType;
 import uk.nhs.hee.tis.trainee.reference.service.DeclarationTypeService;
 
-@ExtendWith(SpringExtension.class)
-@WebMvcTest(controllers = DeclarationTypeResource.class)
 class DeclarationTypeResourceTest {
 
   private static final String DEFAULT_ID_1 = "DEFAULT_ID_1";
@@ -56,72 +42,37 @@ class DeclarationTypeResourceTest {
   private static final String DEFAULT_LABEL_1 = "Significant event";
   private static final String DEFAULT_LABEL_2 = "Other investigation";
 
-  @Autowired
-  private MappingJackson2HttpMessageConverter jacksonMessageConverter;
+  private DeclarationTypeResource controller;
+  private DeclarationTypeService service;
 
-  private MockMvc mockMvc;
-
-  @MockBean
-  private DeclarationTypeService declarationTypeServiceMock;
-
-  @MockBean
-  private DeclarationTypeMapper declarationTypeMapperMock;
-
-  private DeclarationType declarationType1;
-  private DeclarationType declarationType2;
-  private DeclarationTypeDto declarationTypeDto1;
-  private DeclarationTypeDto declarationTypeDto2;
-
-  /**
-   * Set up mocks before each test.
-   */
   @BeforeEach
   public void setup() {
-    DeclarationTypeResource declarationTypeResource =
-        new DeclarationTypeResource(declarationTypeServiceMock, declarationTypeMapperMock);
-    mockMvc = MockMvcBuilders.standaloneSetup(declarationTypeResource)
-        .setMessageConverters(jacksonMessageConverter)
-        .build();
-  }
-
-  /**
-   * Set up data.
-   */
-  @BeforeEach
-  public void initData() {
-    declarationType1 = new DeclarationType();
-    declarationType1.setId(DEFAULT_ID_1);
-    declarationType1.setLabel(DEFAULT_LABEL_1);
-
-    declarationType2 = new DeclarationType();
-    declarationType2.setId(DEFAULT_ID_2);
-    declarationType2.setLabel(DEFAULT_LABEL_2);
-
-    declarationTypeDto1 = new DeclarationTypeDto();
-    declarationTypeDto1.setId(DEFAULT_ID_1);
-    declarationTypeDto1.setLabel(DEFAULT_LABEL_1);
-
-    declarationTypeDto2 = new DeclarationTypeDto();
-    declarationTypeDto2.setId(DEFAULT_ID_2);
-    declarationTypeDto2.setLabel(DEFAULT_LABEL_2);
+    service = mock(DeclarationTypeService.class);
+    controller = new DeclarationTypeResource(service, new DeclarationTypeMapperImpl());
   }
 
   @Test
-  void testGetAllDeclarationType() throws Exception {
-    List<DeclarationType> declarationType = new ArrayList<>();
-    declarationType.add(declarationType1);
-    declarationType.add(declarationType2);
-    List<DeclarationTypeDto> declarationTypeDtos = new ArrayList<>();
-    declarationTypeDtos.add(declarationTypeDto1);
-    declarationTypeDtos.add(declarationTypeDto2);
-    when(declarationTypeServiceMock.getDeclarationType()).thenReturn(declarationType);
-    when(declarationTypeMapperMock.toDtos(declarationType)).thenReturn(declarationTypeDtos);
-    this.mockMvc.perform(get("/api/declaration-type")
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$").value(hasSize(declarationTypeDtos.size())))
-        .andExpect(jsonPath("$.[*].id").value(hasItem(DEFAULT_ID_1)))
-        .andExpect(jsonPath("$.[*].id").value(hasItem(DEFAULT_ID_2)));
+  void shouldGetAllDeclarationType() {
+    DeclarationType entity1 = new DeclarationType();
+    entity1.setId(DEFAULT_ID_1);
+    entity1.setLabel(DEFAULT_LABEL_1);
+
+    DeclarationType entity2 = new DeclarationType();
+    entity2.setId(DEFAULT_ID_2);
+    entity2.setLabel(DEFAULT_LABEL_2);
+
+    when(service.getDeclarationType()).thenReturn(List.of(entity1, entity2));
+
+    List<DeclarationTypeDto> dtos = controller.getDeclarationTypes();
+
+    assertThat("Unexpected response count.", dtos, hasSize(2));
+
+    DeclarationTypeDto dto1 = dtos.get(0);
+    assertThat("Unexpected ID.", dto1.getId(), is(DEFAULT_ID_1));
+    assertThat("Unexpected label.", dto1.getLabel(), is(DEFAULT_LABEL_1));
+
+    DeclarationTypeDto dto2 = dtos.get(1);
+    assertThat("Unexpected ID.", dto2.getId(), is(DEFAULT_ID_2));
+    assertThat("Unexpected label.", dto2.getLabel(), is(DEFAULT_LABEL_2));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/GenderResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/GenderResourceTest.java
@@ -21,42 +21,29 @@
 
 package uk.nhs.hee.tis.trainee.reference.api;
 
-import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.OK;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.ArrayList;
+import java.net.URI;
 import java.util.List;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mapstruct.factory.Mappers;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import uk.nhs.hee.tis.trainee.reference.mapper.GenderMapper;
+import org.springframework.http.ResponseEntity;
+import uk.nhs.hee.tis.trainee.reference.dto.GenderDto;
+import uk.nhs.hee.tis.trainee.reference.mapper.GenderMapperImpl;
 import uk.nhs.hee.tis.trainee.reference.model.Gender;
 import uk.nhs.hee.tis.trainee.reference.service.GenderService;
 
-@ContextConfiguration(classes = {GenderMapper.class})
-@ExtendWith(SpringExtension.class)
-@WebMvcTest(GenderResource.class)
 class GenderResourceTest {
 
   private static final String DEFAULT_ID_1 = "DEFAULT_ID_1";
@@ -68,30 +55,13 @@ class GenderResourceTest {
   private static final String DEFAULT_LABEL_1 = "Male";
   private static final String DEFAULT_LABEL_2 = "Female";
 
-  @Autowired
-  private MappingJackson2HttpMessageConverter jacksonMessageConverter;
+  private GenderResource controller;
+  private GenderService service;
 
-  @Autowired
-  private ObjectMapper mapper;
-
-  private MockMvc mockMvc;
-
-  @MockBean
-  private GenderService genderServiceMock;
-
-  private Gender gender1;
-  private Gender gender2;
-
-  /**
-   * Set up mocks before each test.
-   */
   @BeforeEach
   void setup() {
-    GenderMapper mapper = Mappers.getMapper(GenderMapper.class);
-    GenderResource genderResource = new GenderResource(genderServiceMock, mapper);
-    mockMvc = MockMvcBuilders.standaloneSetup(genderResource)
-        .setMessageConverters(jacksonMessageConverter)
-        .build();
+    service = mock(GenderService.class);
+    controller = new GenderResource(service, new GenderMapperImpl());
   }
 
   /**
@@ -99,67 +69,99 @@ class GenderResourceTest {
    */
   @BeforeEach
   void initData() {
-    gender1 = new Gender();
-    gender1.setId(DEFAULT_ID_1);
-    gender1.setTisId(DEFAULT_TIS_ID_1);
-    gender1.setLabel(DEFAULT_LABEL_1);
+    Gender entity1 = new Gender();
+    entity1.setId(DEFAULT_ID_1);
+    entity1.setTisId(DEFAULT_TIS_ID_1);
+    entity1.setLabel(DEFAULT_LABEL_1);
 
-    gender2 = new Gender();
-    gender2.setId(DEFAULT_ID_2);
-    gender2.setTisId(DEFAULT_TIS_ID_2);
-    gender2.setLabel(DEFAULT_LABEL_2);
+    Gender entity2 = new Gender();
+    entity2.setId(DEFAULT_ID_2);
+    entity2.setTisId(DEFAULT_TIS_ID_2);
+    entity2.setLabel(DEFAULT_LABEL_2);
   }
 
   @Test
-  void testGetAllGenders() throws Exception {
-    List<Gender> genders = new ArrayList<>();
-    genders.add(gender1);
-    genders.add(gender2);
-    when(genderServiceMock.get()).thenReturn(genders);
-    this.mockMvc.perform(get("/api/gender")
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$").value(hasSize(2)))
-        .andExpect(jsonPath("$.[*].id").value(hasItem(DEFAULT_ID_1)))
-        .andExpect(jsonPath("$.[*].id").value(hasItem(DEFAULT_ID_2)));
+  void shouldGetAllGenders() {
+    Gender entity1 = new Gender();
+    entity1.setId(DEFAULT_ID_1);
+    entity1.setTisId(DEFAULT_TIS_ID_1);
+    entity1.setLabel(DEFAULT_LABEL_1);
+
+    Gender entity2 = new Gender();
+    entity2.setId(DEFAULT_ID_2);
+    entity2.setTisId(DEFAULT_TIS_ID_2);
+    entity2.setLabel(DEFAULT_LABEL_2);
+
+    when(service.get()).thenReturn(List.of(entity1, entity2));
+
+    List<GenderDto> dtos = controller.getGenders();
+
+    assertThat("Unexpected response count.", dtos, hasSize(2));
+
+    GenderDto dto1 = dtos.get(0);
+    assertThat("Unexpected ID.", dto1.getId(), CoreMatchers.is(DEFAULT_ID_1));
+    assertThat("Unexpected TIS ID.", dto1.getTisId(), CoreMatchers.is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected label.", dto1.getLabel(), CoreMatchers.is(DEFAULT_LABEL_1));
+
+    GenderDto dto2 = dtos.get(1);
+    assertThat("Unexpected ID.", dto2.getId(), CoreMatchers.is(DEFAULT_ID_2));
+    assertThat("Unexpected TIS ID.", dto2.getTisId(), CoreMatchers.is(DEFAULT_TIS_ID_2));
+    assertThat("Unexpected label.", dto2.getLabel(), CoreMatchers.is(DEFAULT_LABEL_2));
   }
 
   @Test
-  void testCreateGender() throws Exception {
-    when(genderServiceMock.create(gender1)).thenReturn(gender1);
+  void shouldCreateGender() {
+    GenderDto dto = new GenderDto();
+    dto.setTisId(DEFAULT_TIS_ID_1);
+    dto.setLabel(DEFAULT_LABEL_1);
 
-    mockMvc.perform(post("/api/gender")
-        .content(mapper.writeValueAsBytes(gender1))
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isCreated())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.id").value(is(DEFAULT_ID_1)))
-        .andExpect(jsonPath("$.tisId").value(is(DEFAULT_TIS_ID_1)))
-        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_1)));
+    when(service.create(any())).thenAnswer(inv -> {
+      Gender entity = inv.getArgument(0);
+      assertThat("Unexpected ID.", entity.getId(), nullValue());
+      entity.setId(DEFAULT_ID_1);
+      return entity;
+    });
+
+    ResponseEntity<GenderDto> response = controller.createGender(dto);
+
+    assertThat("Unexpected status code.", response.getStatusCode(), CoreMatchers.is(CREATED));
+    assertThat("Unexpected location.", response.getHeaders().getLocation(),
+        CoreMatchers.is(URI.create("/api/gender")));
+
+    GenderDto body = response.getBody();
+    assertThat("Unexpected body.", body, notNullValue());
+    assertThat("Unexpected ID.", body.getId(), CoreMatchers.is(DEFAULT_ID_1));
+    assertThat("Unexpected TIS ID.", body.getTisId(), CoreMatchers.is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected label.", body.getLabel(), CoreMatchers.is(DEFAULT_LABEL_1));
   }
 
   @Test
-  void testUpdateGender() throws Exception {
-    when(genderServiceMock.update(gender1)).thenReturn(gender1);
+  void shouldUpdateGender() {
+    GenderDto dto = new GenderDto();
+    dto.setId(DEFAULT_ID_1);
+    dto.setTisId(DEFAULT_TIS_ID_1);
+    dto.setLabel(DEFAULT_LABEL_1);
 
-    mockMvc.perform(put("/api/gender")
-        .content(mapper.writeValueAsBytes(gender1))
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.id").value(is(DEFAULT_ID_1)))
-        .andExpect(jsonPath("$.tisId").value(is(DEFAULT_TIS_ID_1)))
-        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_1)));
+    when(service.update(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    ResponseEntity<GenderDto> response = controller.updateGender(dto);
+
+    assertThat("Unexpected status code.", response.getStatusCode(), CoreMatchers.is(OK));
+
+    GenderDto body = response.getBody();
+    assertThat("Unexpected body.", body, notNullValue());
+    assertThat("Unexpected ID.", body.getId(), CoreMatchers.is(DEFAULT_ID_1));
+    assertThat("Unexpected TIS ID.", body.getTisId(), CoreMatchers.is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected label.", body.getLabel(), CoreMatchers.is(DEFAULT_LABEL_1));
   }
 
   @Test
-  void testDeleteGender() throws Exception {
-    mockMvc.perform(delete("/api/gender/{tisId}", DEFAULT_TIS_ID_1)
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isNoContent())
-        .andExpect(jsonPath("$").doesNotExist());
+  void shouldDeleteGender() {
+    ResponseEntity<Void> response = controller.deleteGender(DEFAULT_TIS_ID_1);
 
-    verify(genderServiceMock).deleteByTisId(DEFAULT_TIS_ID_1);
+    assertThat("Unexpected status code.", response.getStatusCode(), CoreMatchers.is(NO_CONTENT));
+    assertThat("Unexpected response body presence.", response.hasBody(), CoreMatchers.is(false));
+
+    verify(service).deleteByTisId(DEFAULT_TIS_ID_1);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/ImmigrationStatusResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/ImmigrationStatusResourceTest.java
@@ -20,42 +20,29 @@
 
 package uk.nhs.hee.tis.trainee.reference.api;
 
-import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.OK;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.ArrayList;
+import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mapstruct.factory.Mappers;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import uk.nhs.hee.tis.trainee.reference.mapper.ImmigrationStatusMapper;
+import org.springframework.http.ResponseEntity;
+import uk.nhs.hee.tis.trainee.reference.dto.ImmigrationStatusDto;
+import uk.nhs.hee.tis.trainee.reference.mapper.ImmigrationStatusMapperImpl;
 import uk.nhs.hee.tis.trainee.reference.model.ImmigrationStatus;
 import uk.nhs.hee.tis.trainee.reference.service.ImmigrationStatusService;
 
-@ContextConfiguration(classes = {ImmigrationStatusMapper.class})
-@ExtendWith(SpringExtension.class)
-@WebMvcTest(ImmigrationStatusResource.class)
 class ImmigrationStatusResourceTest {
 
   private static final String DEFAULT_ID_1 = "DEFAULT_ID_1";
@@ -67,31 +54,13 @@ class ImmigrationStatusResourceTest {
   private static final String DEFAULT_LABEL_1 = "EEA Resident";
   private static final String DEFAULT_LABEL_2 = "Settled";
 
-  @Autowired
-  private MappingJackson2HttpMessageConverter jacksonMessageConverter;
+  private ImmigrationStatusResource controller;
+  private ImmigrationStatusService service;
 
-  @Autowired
-  private ObjectMapper mapper;
-
-  private MockMvc mockMvc;
-
-  @MockBean
-  private ImmigrationStatusService immigrationStatusServiceMock;
-
-  private ImmigrationStatus immigrationStatus1;
-  private ImmigrationStatus immigrationStatus2;
-
-  /**
-   * Set up mocks before each test.
-   */
   @BeforeEach
   void setup() {
-    ImmigrationStatusMapper mapper = Mappers.getMapper(ImmigrationStatusMapper.class);
-    ImmigrationStatusResource immigrationStatusResource =
-        new ImmigrationStatusResource(immigrationStatusServiceMock, mapper);
-    mockMvc = MockMvcBuilders.standaloneSetup(immigrationStatusResource)
-        .setMessageConverters(jacksonMessageConverter)
-        .build();
+    service = mock(ImmigrationStatusService.class);
+    controller = new ImmigrationStatusResource(service, new ImmigrationStatusMapperImpl());
   }
 
   /**
@@ -99,69 +68,99 @@ class ImmigrationStatusResourceTest {
    */
   @BeforeEach
   void initData() {
-    immigrationStatus1 = new ImmigrationStatus();
-    immigrationStatus1.setId(DEFAULT_ID_1);
-    immigrationStatus1.setTisId(DEFAULT_TIS_ID_1);
-    immigrationStatus1.setLabel(DEFAULT_LABEL_1);
+    ImmigrationStatus entity1 = new ImmigrationStatus();
+    entity1.setId(DEFAULT_ID_1);
+    entity1.setTisId(DEFAULT_TIS_ID_1);
+    entity1.setLabel(DEFAULT_LABEL_1);
 
-    immigrationStatus2 = new ImmigrationStatus();
-    immigrationStatus2.setId(DEFAULT_ID_2);
-    immigrationStatus2.setTisId(DEFAULT_TIS_ID_2);
-    immigrationStatus2.setLabel(DEFAULT_LABEL_2);
+    ImmigrationStatus entity2 = new ImmigrationStatus();
+    entity2.setId(DEFAULT_ID_2);
+    entity2.setTisId(DEFAULT_TIS_ID_2);
+    entity2.setLabel(DEFAULT_LABEL_2);
   }
 
   @Test
-  void testGetAllImmigrationStatus() throws Exception {
-    List<ImmigrationStatus> immigrationStatus = new ArrayList<>();
-    immigrationStatus.add(immigrationStatus1);
-    immigrationStatus.add(immigrationStatus2);
-    when(immigrationStatusServiceMock.get()).thenReturn(immigrationStatus);
-    this.mockMvc.perform(get("/api/immigration-status")
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$").value(hasSize(2)))
-        .andExpect(jsonPath("$.[*].id").value(hasItem(DEFAULT_ID_1)))
-        .andExpect(jsonPath("$.[*].id").value(hasItem(DEFAULT_ID_2)));
+  void shouldGetAllImmigrationStatus() {
+    ImmigrationStatus entity1 = new ImmigrationStatus();
+    entity1.setId(DEFAULT_ID_1);
+    entity1.setTisId(DEFAULT_TIS_ID_1);
+    entity1.setLabel(DEFAULT_LABEL_1);
+
+    ImmigrationStatus entity2 = new ImmigrationStatus();
+    entity2.setId(DEFAULT_ID_2);
+    entity2.setTisId(DEFAULT_TIS_ID_2);
+    entity2.setLabel(DEFAULT_LABEL_2);
+
+    when(service.get()).thenReturn(List.of(entity1, entity2));
+
+    List<ImmigrationStatusDto> dtos = controller.getImmigrationStatuses();
+
+    assertThat("Unexpected response count.", dtos, hasSize(2));
+
+    ImmigrationStatusDto dto1 = dtos.get(0);
+    assertThat("Unexpected ID.", dto1.getId(), is(DEFAULT_ID_1));
+    assertThat("Unexpected TIS ID.", dto1.getTisId(), is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected label.", dto1.getLabel(), is(DEFAULT_LABEL_1));
+
+    ImmigrationStatusDto dto2 = dtos.get(1);
+    assertThat("Unexpected ID.", dto2.getId(), is(DEFAULT_ID_2));
+    assertThat("Unexpected TIS ID.", dto2.getTisId(), is(DEFAULT_TIS_ID_2));
+    assertThat("Unexpected label.", dto2.getLabel(), is(DEFAULT_LABEL_2));
   }
 
   @Test
-  void testCreateImmigrationStatus() throws Exception {
-    when(immigrationStatusServiceMock.create(immigrationStatus1))
-        .thenReturn(immigrationStatus1);
+  void shouldCreateImmigrationStatus() {
+    ImmigrationStatusDto dto = new ImmigrationStatusDto();
+    dto.setTisId(DEFAULT_TIS_ID_1);
+    dto.setLabel(DEFAULT_LABEL_1);
 
-    mockMvc.perform(post("/api/immigration-status")
-        .content(mapper.writeValueAsBytes(immigrationStatus1))
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isCreated())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.id").value(is(DEFAULT_ID_1)))
-        .andExpect(jsonPath("$.tisId").value(is(DEFAULT_TIS_ID_1)))
-        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_1)));
+    when(service.create(any())).thenAnswer(inv -> {
+      ImmigrationStatus entity = inv.getArgument(0);
+      assertThat("Unexpected ID.", entity.getId(), nullValue());
+      entity.setId(DEFAULT_ID_1);
+      return entity;
+    });
+
+    ResponseEntity<ImmigrationStatusDto> response = controller.createImmigrationStatus(dto);
+
+    assertThat("Unexpected status code.", response.getStatusCode(), is(CREATED));
+    assertThat("Unexpected location.", response.getHeaders().getLocation(),
+        is(URI.create("/api/immigration-status")));
+
+    ImmigrationStatusDto body = response.getBody();
+    assertThat("Unexpected body.", body, notNullValue());
+    assertThat("Unexpected ID.", body.getId(), is(DEFAULT_ID_1));
+    assertThat("Unexpected TIS ID.", body.getTisId(), is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected label.", body.getLabel(), is(DEFAULT_LABEL_1));
   }
 
   @Test
-  void testUpdateImmigrationStatus() throws Exception {
-    when(immigrationStatusServiceMock.update(immigrationStatus1))
-        .thenReturn(immigrationStatus1);
+  void shouldUpdateImmigrationStatus() {
+    ImmigrationStatusDto dto = new ImmigrationStatusDto();
+    dto.setId(DEFAULT_ID_1);
+    dto.setTisId(DEFAULT_TIS_ID_1);
+    dto.setLabel(DEFAULT_LABEL_1);
 
-    mockMvc.perform(put("/api/immigration-status")
-        .content(mapper.writeValueAsBytes(immigrationStatus1))
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.id").value(is(DEFAULT_ID_1)))
-        .andExpect(jsonPath("$.tisId").value(is(DEFAULT_TIS_ID_1)))
-        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_1)));
+    when(service.update(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    ResponseEntity<ImmigrationStatusDto> response = controller.updateImmigrationStatus(dto);
+
+    assertThat("Unexpected status code.", response.getStatusCode(), is(OK));
+
+    ImmigrationStatusDto body = response.getBody();
+    assertThat("Unexpected body.", body, notNullValue());
+    assertThat("Unexpected ID.", body.getId(), is(DEFAULT_ID_1));
+    assertThat("Unexpected TIS ID.", body.getTisId(), is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected label.", body.getLabel(), is(DEFAULT_LABEL_1));
   }
 
   @Test
-  void testDeleteImmigrationStatus() throws Exception {
-    mockMvc.perform(delete("/api/immigration-status/{tisId}", DEFAULT_TIS_ID_1)
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isNoContent())
-        .andExpect(jsonPath("$").doesNotExist());
+  void shouldDeleteImmigrationStatus() {
+    ResponseEntity<Void> response = controller.deleteImmigrationStatus(DEFAULT_TIS_ID_1);
 
-    verify(immigrationStatusServiceMock).deleteByTisId(DEFAULT_TIS_ID_1);
+    assertThat("Unexpected status code.", response.getStatusCode(), is(NO_CONTENT));
+    assertThat("Unexpected response body presence.", response.hasBody(), is(false));
+
+    verify(service).deleteByTisId(DEFAULT_TIS_ID_1);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/ProgrammeMembershipTypeResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/ProgrammeMembershipTypeResourceTest.java
@@ -79,7 +79,8 @@ class ProgrammeMembershipTypeResourceTest {
 
     when(service.get()).thenReturn(List.of(entity1, entity2));
 
-    ResponseEntity<List<ProgrammeMembershipTypeDto>> response = controller.getProgrammeMembershipTypes();
+    ResponseEntity<List<ProgrammeMembershipTypeDto>> response
+        = controller.getProgrammeMembershipTypes();
 
     assertThat("Unexpected status code.", response.getStatusCode(), is(OK));
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/ProgrammeMembershipTypeResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/ProgrammeMembershipTypeResourceTest.java
@@ -21,42 +21,29 @@
 
 package uk.nhs.hee.tis.trainee.reference.api;
 
-import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.OK;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.ArrayList;
+import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mapstruct.factory.Mappers;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import uk.nhs.hee.tis.trainee.reference.mapper.ProgrammeMembershipTypeMapper;
+import org.springframework.http.ResponseEntity;
+import uk.nhs.hee.tis.trainee.reference.dto.ProgrammeMembershipTypeDto;
+import uk.nhs.hee.tis.trainee.reference.mapper.ProgrammeMembershipTypeMapperImpl;
 import uk.nhs.hee.tis.trainee.reference.model.ProgrammeMembershipType;
 import uk.nhs.hee.tis.trainee.reference.service.ProgrammeMembershipTypeService;
 
-@ContextConfiguration(classes = {ProgrammeMembershipTypeMapper.class})
-@ExtendWith(SpringExtension.class)
-@WebMvcTest(DbcResource.class)
 class ProgrammeMembershipTypeResourceTest {
 
   private static final String DEFAULT_ID_1 = "DEFAULT_ID_1";
@@ -68,101 +55,103 @@ class ProgrammeMembershipTypeResourceTest {
   private static final String DEFAULT_LABEL_1 = "Substantive";
   private static final String DEFAULT_LABEL_2 = "Military";
 
-  @Autowired
-  private MappingJackson2HttpMessageConverter jacksonMessageConverter;
+  private ProgrammeMembershipTypeResource controller;
+  private ProgrammeMembershipTypeService service;
 
-  @Autowired
-  private ObjectMapper mapper;
-
-  private MockMvc mockMvc;
-
-  @MockBean
-  private ProgrammeMembershipTypeService programmeMembershipTypeServiceMock;
-
-  private ProgrammeMembershipType programmeMembershipType1;
-  private ProgrammeMembershipType programmeMembershipType2;
-
-  /**
-   * Set up mocks before each test.
-   */
   @BeforeEach
   void setup() {
-    ProgrammeMembershipTypeMapper mapper = Mappers.getMapper(ProgrammeMembershipTypeMapper.class);
-    ProgrammeMembershipTypeResource programmeMembershipTypeResource
-        = new ProgrammeMembershipTypeResource(programmeMembershipTypeServiceMock, mapper);
-    mockMvc = MockMvcBuilders.standaloneSetup(programmeMembershipTypeResource)
-        .setMessageConverters(jacksonMessageConverter)
-        .build();
-  }
-
-  /**
-   * Set up data.
-   */
-  @BeforeEach
-  void initData() {
-    programmeMembershipType1 = new ProgrammeMembershipType();
-    programmeMembershipType1.setId(DEFAULT_ID_1);
-    programmeMembershipType1.setTisId(DEFAULT_TIS_ID_1);
-    programmeMembershipType1.setLabel(DEFAULT_LABEL_1);
-
-    programmeMembershipType2 = new ProgrammeMembershipType();
-    programmeMembershipType2.setId(DEFAULT_ID_2);
-    programmeMembershipType2.setTisId(DEFAULT_TIS_ID_2);
-    programmeMembershipType2.setLabel(DEFAULT_LABEL_2);
+    service = mock(ProgrammeMembershipTypeService.class);
+    controller = new ProgrammeMembershipTypeResource(service,
+        new ProgrammeMembershipTypeMapperImpl());
   }
 
   @Test
-  void testGetAllProgrammeMembershipTypes() throws Exception {
-    List<ProgrammeMembershipType> programmeMembershipTypes = new ArrayList<>();
-    programmeMembershipTypes.add(programmeMembershipType1);
-    programmeMembershipTypes.add(programmeMembershipType2);
-    when(programmeMembershipTypeServiceMock.get()).thenReturn(programmeMembershipTypes);
-    this.mockMvc.perform(get("/api/programme-membership-type")
-            .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$").value(hasSize(2)))
-        .andExpect(jsonPath("$.[*].id").value(hasItem(DEFAULT_ID_1)))
-        .andExpect(jsonPath("$.[*].id").value(hasItem(DEFAULT_ID_2)));
+  void shouldGetAllProgrammeMembershipTypes() {
+    ProgrammeMembershipType entity1 = new ProgrammeMembershipType();
+    entity1.setId(DEFAULT_ID_1);
+    entity1.setTisId(DEFAULT_TIS_ID_1);
+    entity1.setLabel(DEFAULT_LABEL_1);
+
+    ProgrammeMembershipType entity2 = new ProgrammeMembershipType();
+    entity2.setId(DEFAULT_ID_2);
+    entity2.setTisId(DEFAULT_TIS_ID_2);
+    entity2.setLabel(DEFAULT_LABEL_2);
+
+    when(service.get()).thenReturn(List.of(entity1, entity2));
+
+    ResponseEntity<List<ProgrammeMembershipTypeDto>> response = controller.getProgrammeMembershipTypes();
+
+    assertThat("Unexpected status code.", response.getStatusCode(), is(OK));
+
+    List<ProgrammeMembershipTypeDto> dtos = response.getBody();
+    assertThat("Unexpected response count.", dtos, hasSize(2));
+
+    ProgrammeMembershipTypeDto dto1 = dtos.get(0);
+    assertThat("Unexpected ID.", dto1.getId(), is(DEFAULT_ID_1));
+    assertThat("Unexpected TIS ID.", dto1.getTisId(), is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected label.", dto1.getLabel(), is(DEFAULT_LABEL_1));
+
+    ProgrammeMembershipTypeDto dto2 = dtos.get(1);
+    assertThat("Unexpected ID.", dto2.getId(), is(DEFAULT_ID_2));
+    assertThat("Unexpected TIS ID.", dto2.getTisId(), is(DEFAULT_TIS_ID_2));
+    assertThat("Unexpected label.", dto2.getLabel(), is(DEFAULT_LABEL_2));
   }
 
   @Test
-  void testCreateProgrammeMembershipType() throws Exception {
-    when(programmeMembershipTypeServiceMock.create(programmeMembershipType1)).thenReturn(
-        programmeMembershipType1);
+  void shouldCreateProgrammeMembershipType() {
+    ProgrammeMembershipTypeDto dto = new ProgrammeMembershipTypeDto();
+    dto.setTisId(DEFAULT_TIS_ID_1);
+    dto.setLabel(DEFAULT_LABEL_1);
 
-    mockMvc.perform(post("/api/programme-membership-type")
-            .content(mapper.writeValueAsBytes(programmeMembershipType1))
-            .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isCreated())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.id").value(is(DEFAULT_ID_1)))
-        .andExpect(jsonPath("$.tisId").value(is(DEFAULT_TIS_ID_1)))
-        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_1)));
+    when(service.create(any())).thenAnswer(inv -> {
+      ProgrammeMembershipType entity = inv.getArgument(0);
+      assertThat("Unexpected ID.", entity.getId(), nullValue());
+      entity.setId(DEFAULT_ID_1);
+      return entity;
+    });
+
+    ResponseEntity<ProgrammeMembershipTypeDto> response = controller.createProgrammeMembershipType(
+        dto);
+
+    assertThat("Unexpected status code.", response.getStatusCode(), is(CREATED));
+    assertThat("Unexpected location.", response.getHeaders().getLocation(),
+        is(URI.create("/api/programme-membership-type")));
+
+    ProgrammeMembershipTypeDto body = response.getBody();
+    assertThat("Unexpected body.", body, notNullValue());
+    assertThat("Unexpected ID.", body.getId(), is(DEFAULT_ID_1));
+    assertThat("Unexpected TIS ID.", body.getTisId(), is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected label.", body.getLabel(), is(DEFAULT_LABEL_1));
   }
 
   @Test
-  void testUpdateProgrammeMembershipType() throws Exception {
-    when(programmeMembershipTypeServiceMock.update(programmeMembershipType1)).thenReturn(
-        programmeMembershipType2);
+  void shouldUpdateProgrammeMembershipType() {
+    ProgrammeMembershipTypeDto dto = new ProgrammeMembershipTypeDto();
+    dto.setId(DEFAULT_ID_1);
+    dto.setTisId(DEFAULT_TIS_ID_1);
+    dto.setLabel(DEFAULT_LABEL_1);
 
-    mockMvc.perform(put("/api/programme-membership-type")
-            .content(mapper.writeValueAsBytes(programmeMembershipType1))
-            .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.id").value(is(DEFAULT_ID_2)))
-        .andExpect(jsonPath("$.tisId").value(is(DEFAULT_TIS_ID_2)))
-        .andExpect(jsonPath("$.label").value(is(DEFAULT_LABEL_2)));
+    when(service.update(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    ResponseEntity<ProgrammeMembershipTypeDto> response = controller.updateProgrammeMembershipType(
+        dto);
+
+    assertThat("Unexpected status code.", response.getStatusCode(), is(OK));
+
+    ProgrammeMembershipTypeDto body = response.getBody();
+    assertThat("Unexpected body.", body, notNullValue());
+    assertThat("Unexpected ID.", body.getId(), is(DEFAULT_ID_1));
+    assertThat("Unexpected TIS ID.", body.getTisId(), is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected label.", body.getLabel(), is(DEFAULT_LABEL_1));
   }
 
   @Test
-  void testDeleteProgrammeMembershipType() throws Exception {
-    mockMvc.perform(delete("/api/programme-membership-type/{tisId}", DEFAULT_TIS_ID_1)
-            .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isNoContent())
-        .andExpect(jsonPath("$").doesNotExist());
+  void shouldDeleteProgrammeMembershipType() {
+    ResponseEntity<Void> response = controller.deleteProgrammeMembershipType(DEFAULT_TIS_ID_1);
 
-    verify(programmeMembershipTypeServiceMock).deleteByTisId(DEFAULT_TIS_ID_1);
+    assertThat("Unexpected status code.", response.getStatusCode(), is(NO_CONTENT));
+    assertThat("Unexpected response body presence.", response.hasBody(), is(false));
+
+    verify(service).deleteByTisId(DEFAULT_TIS_ID_1);
   }
 }


### PR DESCRIPTION
Create a Gradle test suite for integrations tests, move the disabled
TisTraineeApplicationTest to the new suite and enable it.

Rewrite the controller tests, split in to unit tests and integration tests.
The unit tests should provide the actual test coverage, checking all
branches/conditions etc.
The integration tests should verify the main/happy path of each
endpoint against the expected state of the database.

NO-TICKET