### PR TITLE
build: migrate to trainee version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,30 +1,22 @@
 plugins {
   java
-  id("org.springframework.boot") version "3.3.0"
-  id("io.spring.dependency-management") version "1.1.4"
+  alias(libs.plugins.spring.boot)
+  alias(libs.plugins.spring.dependency.management)
 
   // Code quality plugins
   checkstyle
   jacoco
-  id("org.sonarqube") version "4.4.1.3373"
+  alias(libs.plugins.sonarqube)
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.6.0"
+version = "1.6.1"
 
 configurations {
   compileOnly {
     extendsFrom(configurations.annotationProcessor.get())
   }
 }
-
-repositories {
-  mavenCentral()
-}
-
-val mapstructVersion = "1.5.5.Final"
-val mongockVersion = "5.4.2"
-val sentryVersion = "7.10.0"
 
 dependencies {
   // Spring Boot starters
@@ -34,22 +26,21 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-web")
 
   // AWS-XRay
-  implementation("com.amazonaws:aws-xray-recorder-sdk-spring:2.16.0")
+  implementation(libs.aws.xray)
 
   // Lombok
   compileOnly("org.projectlombok:lombok")
   annotationProcessor("org.projectlombok:lombok")
 
   // MapStruct
-  implementation("org.mapstruct:mapstruct:$mapstructVersion")
-  annotationProcessor("org.mapstruct:mapstruct-processor:$mapstructVersion")
+  implementation(libs.mapstruct.core)
+  annotationProcessor(libs.mapstruct.processor)
 
   // Mongock
-  implementation("io.mongock:mongock-springboot:${mongockVersion}")
-  implementation("io.mongock:mongodb-springdata-v4-driver:${mongockVersion}")
+  implementation(libs.bundles.mongock)
 
   // Sentry reporting
-  implementation("io.sentry:sentry-spring-boot-starter-jakarta:$sentryVersion")
+  implementation(libs.sentry.core)
 }
 
 java {
@@ -90,7 +81,7 @@ testing {
 
     val test by getting(JvmTestSuite::class) {
       dependencies {
-        annotationProcessor("org.mapstruct:mapstruct-processor:$mapstructVersion")
+        annotationProcessor(libs.mapstruct.processor)
       }
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,13 @@
 rootProject.name = "tis-trainee-reference"
+
+dependencyResolutionManagement {
+  repositories {
+    mavenCentral()
+  }
+
+  versionCatalogs {
+    create("libs") {
+      from("uk.nhs.tis.trainee:version-catalog:0.0.2")
+    }
+  }
+}


### PR DESCRIPTION
Use the trainee version catalog to determine plugin and dependency versions.

Since the version catalog is based on another service there are some dependency changes

- Sentry downgraded from `7.10.0` to `7.6.0`
- AWS xray downgraded from `2.16.0` to `2.15.1`

These dependencies will be updated again once the version catalog is updated, however the initial goal is consistency so a temporary downgrade is acceptable.

NO-TICKET