### PR TITLE
fix: remove foundation suffix from contacts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.7.0"
+version = "1.7.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/LocalOfficeContactMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/mapper/LocalOfficeContactMapper.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.trainee.reference.mapper;
 
 import java.util.List;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -52,4 +53,20 @@ public interface LocalOfficeContactMapper {
 
   @Mapping(target = "tisId", ignore = true)
   LocalOfficeContact update(@MappingTarget LocalOfficeContact target, LocalOfficeContact source);
+
+  /**
+   * A temporary fix to remove the trainee type workaround suffix from the contact type name until
+   * TIS is updated to remove it. This is needed here so downstream services do not have to know
+   * about the internal workaround.
+   *
+   * @param dto The DTO to update.
+   */
+  @AfterMapping
+  default void trimTraineeTypeSuffix(@MappingTarget LocalOfficeContactDetailsDto dto) {
+    String contactTypeName = dto.getContactTypeName();
+
+    if (contactTypeName != null) {
+      dto.setContactTypeName(contactTypeName.replaceAll(" - Foundation$", ""));
+    }
+  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/service/LocalOfficeContactService.java
@@ -44,6 +44,8 @@ import uk.nhs.hee.tis.trainee.reference.repository.LocalOfficeContactRepository;
 @Slf4j
 public class LocalOfficeContactService extends AbstractReferenceService<LocalOfficeContact> {
 
+  private static final String FOUNDATION_LABEL_SUFFIX = " - Foundation";
+
   private final LocalOfficeContactMapper mapper;
   private final LocalOfficeContactRepository repository;
   private final LocalOfficeContactEnricherFacade facade;
@@ -111,10 +113,10 @@ public class LocalOfficeContactService extends AbstractReferenceService<LocalOff
 
           if (traineeType == FOUNDATION) {
             // Foundation contact types are suffixed with " - Foundation".
-            return contactTypeName.endsWith(" - Foundation");
+            return contactTypeName.endsWith(FOUNDATION_LABEL_SUFFIX);
           } else {
             // Assume specialty, which has no suffix.
-            return !contactTypeName.endsWith(" - Foundation");
+            return !contactTypeName.endsWith(FOUNDATION_LABEL_SUFFIX);
           }
         })
         .toList();

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeContactResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/api/LocalOfficeContactResourceTest.java
@@ -40,6 +40,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.http.ResponseEntity;
 import uk.nhs.hee.tis.trainee.reference.dto.LocalOfficeContactDetailsDto;
@@ -154,6 +155,29 @@ class LocalOfficeContactResourceTest {
   }
 
   @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      FOUNDATION    | ' - Foundation'
+      SPECIALTY     | ''
+      """)
+  void shouldGetAllLocalOfficeContactsWithoutTraineeTypeSuffix(TraineeType traineeType,
+      String suffix) {
+    LocalOfficeContact entity = new LocalOfficeContact();
+    entity.setTisId(DEFAULT_TIS_ID_1);
+    entity.setContactTypeName(DEFAULT_CONTACT_TYPE_NAME_1 + suffix);
+
+    when(service.get(traineeType)).thenReturn(List.of(entity));
+
+    List<LocalOfficeContactDetailsDto> dtos = controller.getLocalOfficeContacts(traineeType);
+
+    assertThat("Unexpected response count.", dtos, hasSize(1));
+
+    LocalOfficeContactDetailsDto dto = dtos.get(0);
+    assertThat("Unexpected TIS ID.", dto.getTisId(), is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected contact type name.", dto.getContactTypeName(),
+        is(DEFAULT_CONTACT_TYPE_NAME_1));
+  }
+
+  @ParameterizedTest
   @EnumSource(TraineeType.class)
   void shouldGetLocalOfficeContactsByLoUuid(TraineeType traineeType) {
     LocalOfficeContact entity = new LocalOfficeContact();
@@ -188,6 +212,34 @@ class LocalOfficeContactResourceTest {
   }
 
   @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      FOUNDATION    | ' - Foundation'
+      SPECIALTY     | ''
+      """)
+  void shouldGetLocalOfficeContactsByLoUuidWithoutTraineeTypeSuffix(TraineeType traineeType,
+      String suffix) {
+    LocalOfficeContact entity = new LocalOfficeContact();
+    entity.setTisId(DEFAULT_TIS_ID_1);
+    entity.setLocalOfficeId(DEFAULT_LOCAL_OFFICE_ID_1);
+    entity.setContactTypeName(DEFAULT_CONTACT_TYPE_NAME_1 + suffix);
+
+    when(service.getByLocalOfficeUuid(DEFAULT_LOCAL_OFFICE_ID_1, traineeType)).thenReturn(
+        List.of(entity));
+
+    List<LocalOfficeContactDetailsDto> dtos = controller.getLocalOfficeContactsByLoUuid(
+        DEFAULT_LOCAL_OFFICE_ID_1, traineeType);
+
+    assertThat("Unexpected response count.", dtos, hasSize(1));
+
+    LocalOfficeContactDetailsDto dto = dtos.get(0);
+    assertThat("Unexpected TIS ID.", dto.getTisId(), is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected local office ID.", dto.getLocalOfficeId(),
+        is(DEFAULT_LOCAL_OFFICE_ID_1));
+    assertThat("Unexpected contact type name.", dto.getContactTypeName(),
+        is(DEFAULT_CONTACT_TYPE_NAME_1));
+  }
+
+  @ParameterizedTest
   @EnumSource(TraineeType.class)
   void shouldGetLocalOfficeContactsByLoName(TraineeType traineeType) {
     LocalOfficeContact entity = new LocalOfficeContact();
@@ -218,6 +270,34 @@ class LocalOfficeContactResourceTest {
     assertThat("Unexpected local office name.", dto1.getLocalOfficeName(),
         is(DEFAULT_LOCAL_OFFICE_NAME_1));
     assertThat("Unexpected contact type name.", dto1.getContactTypeName(),
+        is(DEFAULT_CONTACT_TYPE_NAME_1));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      FOUNDATION    | ' - Foundation'
+      SPECIALTY     | ''
+      """)
+  void shouldGetLocalOfficeContactsByLoNameWithoutTraineeTypeSuffix(TraineeType traineeType,
+      String suffix) {
+    LocalOfficeContact entity = new LocalOfficeContact();
+    entity.setTisId(DEFAULT_TIS_ID_1);
+    entity.setLocalOfficeName(DEFAULT_LOCAL_OFFICE_NAME_1);
+    entity.setContactTypeName(DEFAULT_CONTACT_TYPE_NAME_1 + suffix);
+
+    when(service.getByLocalOfficeName(DEFAULT_LOCAL_OFFICE_NAME_1, traineeType)).thenReturn(
+        List.of(entity));
+
+    List<LocalOfficeContactDetailsDto> dtos = controller.getLocalOfficeContactsByLoName(
+        DEFAULT_LOCAL_OFFICE_NAME_1, traineeType);
+
+    assertThat("Unexpected response count.", dtos, hasSize(1));
+
+    LocalOfficeContactDetailsDto dto = dtos.get(0);
+    assertThat("Unexpected TIS ID.", dto.getTisId(), is(DEFAULT_TIS_ID_1));
+    assertThat("Unexpected local office name.", dto.getLocalOfficeName(),
+        is(DEFAULT_LOCAL_OFFICE_NAME_1));
+    assertThat("Unexpected contact type name.", dto.getContactTypeName(),
         is(DEFAULT_CONTACT_TYPE_NAME_1));
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/mapper/LocalOfficeContactMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/mapper/LocalOfficeContactMapperTest.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.reference.mapper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import uk.nhs.hee.tis.trainee.reference.dto.LocalOfficeContactDetailsDto;
+
+/**
+ * Tests for default {@link LocalOfficeContactMapper} methods.
+ */
+class LocalOfficeContactMapperTest {
+
+  private LocalOfficeContactMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new LocalOfficeContactMapperImpl();
+  }
+
+  @Test
+  void shouldNotTrimSuffixFromContactTypeNameWhenNull() {
+    LocalOfficeContactDetailsDto dto = new LocalOfficeContactDetailsDto();
+
+    mapper.trimTraineeTypeSuffix(dto);
+
+    assertThat("Unexpected contact type name.", dto.getContactTypeName(), nullValue());
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      Base Name | Base Name
+      Base Name - Foundation | Base Name
+      Base Name - Not Foundation | Base Name - Not Foundation
+      """)
+  void shouldTrimSuffixFromContactTypeNameWhenNotNull(String before, String after) {
+    LocalOfficeContactDetailsDto dto = new LocalOfficeContactDetailsDto();
+    dto.setContactTypeName(before);
+
+    mapper.trimTraineeTypeSuffix(dto);
+
+    assertThat("Unexpected contact type name.", dto.getContactTypeName(), is(after));
+  }
+}


### PR DESCRIPTION
Foundation contacts currently require a workaround, adding a ` - foundation` suffix to contact types. This suffix should not be returned by the API.

Update the LocalOfficeContactMapper to remove any ` - foundation` suffixes from contact type names.

TIS21-8496