### PR TITLE
chore: update task def to use new db credentials

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -18,11 +18,11 @@
         },
         {
           "name": "DB_USER",
-          "valueFrom": "/tis/trainee/${environment}/db/username"
+          "valueFrom": "/tis/trainee/${environment}/db/username/tis-trainee-reference"
         },
         {
           "name": "DB_PASSWORD",
-          "valueFrom": "/tis/trainee/${environment}/db/password"
+          "valueFrom": "/tis/trainee/${environment}/db/password/tis-trainee-reference"
         },
         {
           "name": "SENTRY_DSN",


### PR DESCRIPTION
I am thinking we can replace the name with Sed, but this looks simple enough.
Not looking at Sed because for templates without different db users it will be an issue.