### PR TITLE
refactor: updated handling to conform to the achual update messages c…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.8.0"
+version = "1.8.1"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/event/CollegeListenerIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/reference/event/CollegeListenerIntegrationTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.UUID;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -81,14 +82,19 @@ class CollegeListenerIntegrationTest {
     registry.add("spring.cloud.aws.sqs.enabled", () -> true);
   }
 
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @BeforeEach
+  void setUp() {
+    mongoTemplate.dropCollection(College.class);
+  }
+
   @BeforeAll
   static void setUpBeforeAll() throws IOException, InterruptedException {
     localstack.execInContainer("awslocal", "sqs", "create-queue", "--queue-name",
         COLLEGE_PATCH_QUEUE);
   }
-
-  @Autowired
-  private MongoTemplate mongoTemplate;
 
   @Autowired
   private SqsTemplate sqsTemplate;
@@ -97,6 +103,7 @@ class CollegeListenerIntegrationTest {
   void shouldHandleReplaceEvent() throws JsonProcessingException {
     final String id = ObjectId.get().toString();
     String tisId = UUID.randomUUID().toString();
+    String uuid = UUID.randomUUID().toString();
 
     College college = new College();
     college.setId(id);
@@ -117,9 +124,10 @@ class CollegeListenerIntegrationTest {
               }
             }
           ],
-          "keys": { "id": "%s" }
+          "metadata": { "timestamp": "2026-06-19T10:00:00Z", "schema-name": "reference", "table-name": "College" },
+          "keys": { "uuid": "%s" }
         }
-        """.formatted(tisId, UUID.randomUUID(), tisId);
+        """.formatted(tisId, uuid, uuid);
 
     JsonNode eventJson = JsonMapper.builder()
         .build()
@@ -142,6 +150,7 @@ class CollegeListenerIntegrationTest {
   @Test
   void shouldHandleInsertEvent() throws JsonProcessingException {
     String tisId = UUID.randomUUID().toString();
+    String uuid = UUID.randomUUID().toString();
 
     String eventString = """
         {
@@ -155,9 +164,10 @@ class CollegeListenerIntegrationTest {
               }
             }
           ],
-          "keys": { "id": "%s" }
+          "metadata": { "timestamp": "2026-06-19T10:00:00Z", "schema-name": "reference", "table-name": "College" },
+          "keys": { "uuid": "%s" }
         }
-        """.formatted(tisId, UUID.randomUUID(), tisId);
+        """.formatted(tisId, uuid, uuid);
 
     JsonNode eventJson = JsonMapper.builder()
         .build()
@@ -179,22 +189,70 @@ class CollegeListenerIntegrationTest {
   }
 
   @Test
-  void shouldHandleDeleteEvent() throws JsonProcessingException {
+  void shouldHandleInactiveInsertEvent() throws JsonProcessingException {
     String tisId = UUID.randomUUID().toString();
+    String uuid = UUID.randomUUID().toString();
+
+    String eventString = """
+        {
+          "patch": [
+            { "op": "add", "path": "", "value": {
+                "id": "%s",
+                "abbreviation": "FAC",
+                "name": "Inactive College",
+                "status": "INACTIVE",
+                "uuid": "%s"
+              }
+            }
+          ],
+          "metadata": { "timestamp": "2026-06-19T10:00:00Z", "schema-name": "reference", "table-name": "College" },
+          "keys": { "uuid": "%s" }
+        }
+        """.formatted(tisId, uuid, uuid);
+
+    JsonNode eventJson = JsonMapper.builder()
+        .build()
+        .readTree(eventString);
+
+    sqsTemplate.send(COLLEGE_PATCH_QUEUE, eventJson);
+
+    await()
+        .pollInterval(Duration.ofSeconds(2))
+        .atMost(Duration.ofSeconds(10))
+        .ignoreExceptions()
+        .untilAsserted(() -> {
+          long count = mongoTemplate.count(new Query(), College.class);
+          assertThat("Unexpected college count.", count, is(0L));
+        });
+  }
+
+  @Test
+  void shouldHandleInactiveUpdateEvent() throws JsonProcessingException {
+    String tisId = UUID.randomUUID().toString();
+    String uuid = UUID.randomUUID().toString();
 
     College college = new College();
     college.setTisId(tisId);
-    college.setLabel("College To Delete");
+    college.setLabel("Active College");
     mongoTemplate.insert(college);
 
     String eventString = """
         {
           "patch": [
-            { "op": "remove", "path": "" }
+            { "op": "test", "path": "/status", "value": "CURRENT" },
+            { "op": "replace", "path": "", "value": {
+                "id": "%s",
+                "abbreviation": "FAC",
+                "name": "Active College",
+                "status": "INACTIVE",
+                "uuid": "%s"
+              }
+            }
           ],
-          "keys": { "id": "%s" }
+          "metadata": { "timestamp": "2026-06-19T10:00:00Z", "schema-name": "reference", "table-name": "College" },
+          "keys": { "uuid": "%s" }
         }
-        """.formatted(tisId);
+        """.formatted(tisId, uuid, uuid);
 
     JsonNode eventJson = JsonMapper.builder()
         .build()

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/CdcEvent.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/CdcEvent.java
@@ -102,6 +102,14 @@ public record CdcEvent(
     return new JsonPatch(filtered);
   }
 
+  /**
+   * Determines whether the CDC event represents an inactive record.
+   *
+   * <p>Returns true if the root-path add or replace operation's value contains a
+   * {@code status} field equal to {@code INACTIVE}.
+   *
+   * @return true if the record status is INACTIVE, false otherwise.
+   */
   public boolean isInactive() {
     return operations.stream()
         .filter(op -> op instanceof ReplaceOperation || op instanceof AddOperation)
@@ -111,6 +119,14 @@ public record CdcEvent(
         .anyMatch("INACTIVE"::equals);
   }
 
+  /**
+   * Extracts the TIS ID from the root-path add or replace operation's value.
+   *
+   * <p>Returns the {@code id} field from the patch value, or null if no root-path
+   * add or replace operation is present (e.g. for delete events).
+   *
+   * @return The TIS ID, or null if not present in the patch.
+   */
   public String getTisId() {
     return operations.stream()
         .filter(op -> op instanceof ReplaceOperation || op instanceof AddOperation)

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/CdcEvent.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/dto/CdcEvent.java
@@ -28,6 +28,7 @@ import com.github.fge.jsonpatch.AddOperation;
 import com.github.fge.jsonpatch.JsonPatch;
 import com.github.fge.jsonpatch.JsonPatchOperation;
 import com.github.fge.jsonpatch.RemoveOperation;
+import com.github.fge.jsonpatch.ReplaceOperation;
 import com.github.fge.jsonpatch.TestOperation;
 import java.util.List;
 
@@ -101,10 +102,29 @@ public record CdcEvent(
     return new JsonPatch(filtered);
   }
 
+  public boolean isInactive() {
+    return operations.stream()
+        .filter(op -> op instanceof ReplaceOperation || op instanceof AddOperation)
+        .map(op -> (JsonNode) MAPPER.valueToTree(op))
+        .filter(node -> node.path("path").asText().equals(""))
+        .map(node -> node.path("value").path("status").asText(null))
+        .anyMatch("INACTIVE"::equals);
+  }
+
+  public String getTisId() {
+    return operations.stream()
+        .filter(op -> op instanceof ReplaceOperation || op instanceof AddOperation)
+        .map(op -> (JsonNode) MAPPER.valueToTree(op))
+        .filter(node -> node.path("path").asText().equals(""))
+        .map(node -> node.path("value").path("id").asText(null))
+        .findFirst()
+        .orElse(null);
+  }
+
   /**
    * Represents the key fields used to identify a CDC record.
    *
-   * @param id The TIS ID of the record.
+   * @param uuid The TIS UUID of the record.
    */
-  public record CdcKeys(String id) {}
+  public record CdcKeys(String uuid) {}
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/listener/CollegeListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/listener/CollegeListener.java
@@ -53,14 +53,17 @@ public class CollegeListener {
           service.create(new College(), event.getPatchWithoutTests());
         }
       }
-      case DELETE -> log.warn(
-          "Received unexpected DELETE event for tisId [{}], no action taken.",
-          event.getTisId());
+      case DELETE -> log.warn("Received unexpected DELETE event, no action taken.");
       case UPDATE -> {
+        String tisId = event.getTisId();
+        if (tisId == null) {
+          log.warn("Received UPDATE event with no id in patch, no action taken.");
+          return;
+        }
         if (event.isInactive()) {
-          service.deleteByTisId(event.getTisId());
+          service.deleteByTisId(tisId);
         } else {
-          service.update(event.getTisId(), event.getPatchWithoutTests());
+          service.update(tisId, event.getPatchWithoutTests());
         }
       }
     }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/listener/CollegeListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/listener/CollegeListener.java
@@ -66,6 +66,7 @@ public class CollegeListener {
           service.update(tisId, event.getPatchWithoutTests());
         }
       }
+      default -> log.warn("Received unhandled event type [{}], no action taken.", eventType);
     }
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/reference/listener/CollegeListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/reference/listener/CollegeListener.java
@@ -45,11 +45,24 @@ public class CollegeListener {
 
   @SqsListener("${application.queues.college-patch}")
   void handleCollegePatch(CdcEvent event) throws JsonPatchException, JsonProcessingException {
-    log.info("Received event, type: {}", event.getEventType());
-    switch (event.getEventType()) {
-      case INSERT -> service.create(new College(), event.getPatchWithoutTests());
-      case DELETE -> service.deleteByTisId(event.keys().id());
-      case UPDATE -> service.update(event.keys().id(), event.getPatchWithoutTests());
+    var eventType = event.getEventType();
+    log.info("Received event, type: {}", eventType);
+    switch (eventType) {
+      case INSERT -> {
+        if (!event.isInactive()) {
+          service.create(new College(), event.getPatchWithoutTests());
+        }
+      }
+      case DELETE -> log.warn(
+          "Received unexpected DELETE event for tisId [{}], no action taken.",
+          event.getTisId());
+      case UPDATE -> {
+        if (event.isInactive()) {
+          service.deleteByTisId(event.getTisId());
+        } else {
+          service.update(event.getTisId(), event.getPatchWithoutTests());
+        }
+      }
     }
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CdcEventTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CdcEventTest.java
@@ -119,6 +119,62 @@ class CdcEventTest {
   }
 
   @Test
+  void shouldGetTisIdFromInsertPatch() {
+    CdcEvent event = new CdcEvent(insertPatch, null);
+    assertThat("Unexpected TIS ID.", event.getTisId(), is(TIS_ID));
+  }
+
+  @Test
+  void shouldGetTisIdFromUpdatePatch() {
+    CdcEvent event = new CdcEvent(updatePatch, null);
+    assertThat("Unexpected TIS ID.", event.getTisId(), is(TIS_ID));
+  }
+
+  @Test
+  void shouldReturnNullTisIdFromDeletePatch() {
+    CdcEvent event = new CdcEvent(deletePatch, null);
+    assertThat("Unexpected TIS ID.", event.getTisId(), is((String) null));
+  }
+
+  @Test
+  void shouldReturnFalseWhenStatusIsNotInactive() throws IOException, JsonPointerException {
+    String patchTemplate = """
+      {
+        "id": "%s",
+        "name": "%s",
+        "status": "CURRENT"
+      }
+      """;
+    List<JsonPatchOperation> patch = List.of(
+        new ReplaceOperation(new JsonPointer(""),
+            MAPPER.readTree(patchTemplate.formatted(TIS_ID, "Test"))));
+    CdcEvent event = new CdcEvent(patch, null);
+    assertThat("Unexpected inactive status.", event.isInactive(), is(false));
+  }
+
+  @Test
+  void shouldReturnTrueWhenStatusIsInactive() throws IOException, JsonPointerException {
+    String patchTemplate = """
+      {
+        "id": "%s",
+        "name": "%s",
+        "status": "INACTIVE"
+      }
+      """;
+    List<JsonPatchOperation> patch = List.of(
+        new ReplaceOperation(new JsonPointer(""),
+            MAPPER.readTree(patchTemplate.formatted(TIS_ID, "Test"))));
+    CdcEvent event = new CdcEvent(patch, null);
+    assertThat("Unexpected inactive status.", event.isInactive(), is(true));
+  }
+
+  @Test
+  void shouldReturnFalseWhenNoStatusInPatch() {
+    CdcEvent event = new CdcEvent(deletePatch, null);
+    assertThat("Unexpected inactive status.", event.isInactive(), is(false));
+  }
+
+  @Test
   void shouldGetPatchWithoutTests() throws JsonPatchException {
     CdcEvent event = new CdcEvent(updatePatchWithTest, null);
     JsonPatch patch = event.getPatchWithoutTests();

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CdcEventTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/dto/validator/CdcEventTest.java
@@ -144,7 +144,7 @@ class CdcEventTest {
         "name": "%s",
         "status": "CURRENT"
       }
-      """;
+        """;
     List<JsonPatchOperation> patch = List.of(
         new ReplaceOperation(new JsonPointer(""),
             MAPPER.readTree(patchTemplate.formatted(TIS_ID, "Test"))));
@@ -160,7 +160,7 @@ class CdcEventTest {
         "name": "%s",
         "status": "INACTIVE"
       }
-      """;
+        """;
     List<JsonPatchOperation> patch = List.of(
         new ReplaceOperation(new JsonPointer(""),
             MAPPER.readTree(patchTemplate.formatted(TIS_ID, "Test"))));

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/listener/CollegeListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/listener/CollegeListenerTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -33,7 +34,6 @@ import com.github.fge.jsonpatch.JsonPatchException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.nhs.hee.tis.trainee.reference.dto.CdcEvent;
-import uk.nhs.hee.tis.trainee.reference.dto.CdcEvent.CdcKeys;
 import uk.nhs.hee.tis.trainee.reference.dto.CdcEventType;
 import uk.nhs.hee.tis.trainee.reference.model.College;
 import uk.nhs.hee.tis.trainee.reference.service.CollegeService;
@@ -56,6 +56,7 @@ class CollegeListenerTest {
     CdcEvent event = mock(CdcEvent.class);
     JsonPatch patch = mock(JsonPatch.class);
     when(event.getEventType()).thenReturn(CdcEventType.INSERT);
+    when(event.isInactive()).thenReturn(false);
     when(event.getPatchWithoutTests()).thenReturn(patch);
 
     listener.handleCollegePatch(event);
@@ -64,11 +65,38 @@ class CollegeListenerTest {
   }
 
   @Test
-  void shouldCallDeleteByTisIdOnDeleteEvent() throws JsonPatchException, JsonProcessingException {
+  void shouldNotCallCreateOnInactiveInsertEvent()
+      throws JsonPatchException, JsonProcessingException {
     CdcEvent event = mock(CdcEvent.class);
-    CdcKeys keys = new CdcKeys(TIS_ID);
-    when(event.getEventType()).thenReturn(CdcEventType.DELETE);
-    when(event.keys()).thenReturn(keys);
+    when(event.getEventType()).thenReturn(CdcEventType.INSERT);
+    when(event.isInactive()).thenReturn(true);
+
+    listener.handleCollegePatch(event);
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void shouldCallUpdateOnUpdateEvent() throws JsonPatchException, JsonProcessingException {
+    CdcEvent event = mock(CdcEvent.class);
+    JsonPatch patch = mock(JsonPatch.class);
+    when(event.getEventType()).thenReturn(CdcEventType.UPDATE);
+    when(event.isInactive()).thenReturn(false);
+    when(event.getTisId()).thenReturn(TIS_ID);
+    when(event.getPatchWithoutTests()).thenReturn(patch);
+
+    listener.handleCollegePatch(event);
+
+    verify(service).update(TIS_ID, patch);
+  }
+
+  @Test
+  void shouldCallDeleteByTisIdOnInactiveUpdateEvent()
+      throws JsonPatchException, JsonProcessingException {
+    CdcEvent event = mock(CdcEvent.class);
+    when(event.getEventType()).thenReturn(CdcEventType.UPDATE);
+    when(event.isInactive()).thenReturn(true);
+    when(event.getTisId()).thenReturn(TIS_ID);
 
     listener.handleCollegePatch(event);
 
@@ -76,16 +104,13 @@ class CollegeListenerTest {
   }
 
   @Test
-  void shouldCallUpdateOnUpdateEvent() throws JsonPatchException, JsonProcessingException {
+  void shouldNotInteractWithServiceOnDeleteEvent()
+      throws JsonPatchException, JsonProcessingException {
     CdcEvent event = mock(CdcEvent.class);
-    JsonPatch patch = mock(JsonPatch.class);
-    CdcKeys keys = new CdcKeys(TIS_ID);
-    when(event.getEventType()).thenReturn(CdcEventType.UPDATE);
-    when(event.keys()).thenReturn(keys);
-    when(event.getPatchWithoutTests()).thenReturn(patch);
+    when(event.getEventType()).thenReturn(CdcEventType.DELETE);
 
     listener.handleCollegePatch(event);
 
-    verify(service).update(TIS_ID, patch);
+    verifyNoInteractions(service);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/reference/listener/CollegeListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/reference/listener/CollegeListenerTest.java
@@ -65,6 +65,18 @@ class CollegeListenerTest {
   }
 
   @Test
+  void shouldNotInteractWithServiceOnUpdateEventWithNoTisId()
+      throws JsonPatchException, JsonProcessingException {
+    CdcEvent event = mock(CdcEvent.class);
+    when(event.getEventType()).thenReturn(CdcEventType.UPDATE);
+    when(event.getTisId()).thenReturn(null);
+
+    listener.handleCollegePatch(event);
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
   void shouldNotCallCreateOnInactiveInsertEvent()
       throws JsonPatchException, JsonProcessingException {
     CdcEvent event = mock(CdcEvent.class);


### PR DESCRIPTION
…oming from TIS. updated delete handling to delete any colleges that are updated to inactive

Expected Update Message:
{"patch": [{"op": "test", "path": "/name", "value": "TestCollegePatchupdate"}, {"op": "test", "path": "/status", "value": "INACTIVE"}, {"op": "replace", "path": "", "value": {"id": 26, "abbreviation": "TstCllge", "name": "TestCollegePatchupdate2", "status": "CURRENT", "uuid": "2de83944-6bc1-11f1-a737-063cec3365f8"}}], "metadata": {"timestamp": "2026-06-19T09:34:15.681154Z", "schema-name": "reference", "table-name": "College"}, "keys": {"uuid": "2de83944-6bc1-11f1-a737-063cec3365f8"}}

Expected Delete Triggering messages:
{"patch": [{"op": "test", "path": "/status", "value": "CURRENT"}, {"op": "replace", "path": "", "value": {"id": 26, "abbreviation": "TstCllge", "name": "TestCollegePatchupdate", "status": "INACTIVE", "uuid": "2de83944-6bc1-11f1-a737-063cec3365f8"}}], "metadata": {"timestamp": "2026-06-19T09:33:25.221960Z", "schema-name": "reference", "table-name": "College"}, "keys": {"uuid": "2de83944-6bc1-11f1-a737-063cec3365f8"}}

TICKET
TIS21-7744
TIS21-8360